### PR TITLE
Update API of aggforce and minor fixes

### DIFF
--- a/examples/trpcage.yaml
+++ b/examples/trpcage.yaml
@@ -16,5 +16,4 @@ embedding_func: input_generator.embedding_fivebead
 skip_residues:
 - ACE
 - NME
-use_terminal_embeddings: false
 cg_mapping_strategy: slice_aggregate

--- a/examples/trpcage_sim.yaml
+++ b/examples/trpcage_sim.yaml
@@ -16,5 +16,4 @@ embedding_func: input_generator.embedding_fivebead
 skip_residues:
 - ACE
 - NME
-use_terminal_embeddings: false
 copies: 35

--- a/input_generator/raw_data_loader.py
+++ b/input_generator/raw_data_loader.py
@@ -9,7 +9,60 @@ import warnings
 from pathlib import Path
 
 class DatasetLoader:
-    pass
+    r"""
+    Base loader object for a dataset. Defines the interface that all loader should have.
+
+    As there is no standard way of saving the output of molecular dynamics simulations, 
+    the objective of this is class is to be an interface which will load the MD data
+    from a given dataset stored in a local path. It will further process the data to 
+    remove thing that are not relevant to our system (for example, solvent coordinates
+    and forces) and returned the clean coordinate and force as np.ndarrays and an mdtraj
+    object that carries the topology
+    
+    The loader should be flexible enough to handle datasets with different molecules, 
+    multiple independent trajectories of different length and other things.
+
+
+    """
+    def get_traj_top(self, name: str, pdb_fn: str):
+        r"""
+        Function to get the topology associated with a trajectory in the dataset.
+
+        PDB files represent molecules by putting the position of every atom in cartesian space.
+        From the distances between atoms, covalent bonds and other things can be deduced. 
+        
+        Note that, by convention, raw PDB files use angstroms as the unit of the coordinates.
+        Engines such as Pymol and mdtraj convert this values to nanometers
+
+        Parameters
+        ----------
+        name:
+            Name of input sample (i.e. the molecule or object in the data)
+        pdb_fn:
+            String representing a path to a PDB file which has the topolgy for
+        """
+        raise NotImplementedError(f"Base class {self.__class__} has no implementation")
+    
+    def load_coords_forces(
+        self, base_dir: str, name: str, stride: int = 1,
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        r"""
+        Method to load the coordinate and force data
+
+        This requires the base directory where files can be saved, the name of the molecule
+        we are trying to load and a stride parameter. The stride is useful for cases where
+        the data is saved too frequently.
+
+        Parameters
+        ----------
+        base_dir:
+            Path to coordinate and force files.
+        name:
+            Name of input sample
+        stride : int
+            Interval by which to stride loaded data
+        """
+        raise NotImplementedError(f"Base class {self.__class__} has no implementation")
 
 
 class CATH_loader(DatasetLoader):
@@ -96,7 +149,7 @@ class DIMER_loader(DatasetLoader):
         return aa_traj, top_dataframe
 
     def load_coords_forces(
-        self, base_dir: str, name: str, stride: int = 1
+        self, base_dir: str, name: str, stride: int = 1,
     ) -> Tuple[np.ndarray, np.ndarray]:
         """
         For a given DIMER pair name, returns np.ndarray's of its coordinates and forces at
@@ -148,7 +201,7 @@ class Trpcage_loader(DatasetLoader):
         return aa_traj, top_dataframe
 
     def load_coords_forces(
-        self, base_dir: str, name: str
+        self, base_dir: str, name: str,  stride: int = 1
     ) -> Tuple[np.ndarray, np.ndarray]:
         """
         For a given name, returns np.ndarray's of its coordinates and forces at
@@ -199,7 +252,7 @@ class Cln_loader(DatasetLoader):
         return aa_traj, top_dataframe
 
     def load_coords_forces(
-        self, base_dir: str, name: str
+        self, base_dir: str, name: str, stride: int = 1
     ) -> Tuple[np.ndarray, np.ndarray]:
         coords_fns = natsorted(
             glob(os.path.join(base_dir, f"coords_nowater/chig_coor_*.npy"))
@@ -235,7 +288,7 @@ class Villin_loader(DatasetLoader):
         return aa_traj, top_dataframe
     
     def load_coords_forces(
-            self, base_dir: str, name: str
+            self, base_dir: str, name: str, stride: int =1,
     ) -> Tuple[np.ndarray, np.ndarray]:
         coords_fns = sorted(
             glob(
@@ -289,7 +342,7 @@ class OPEP_loader(DatasetLoader):
         return aa_traj, top_dataframe
 
     def load_coords_forces(
-        self, base_dir: str, name: str
+        self, base_dir: str, name: str, stride: int =1,
     ) -> Tuple[np.ndarray, np.ndarray]:
         """
         For a given CATH domain name, returns np.ndarray's of its coordinates and forces at

--- a/input_generator/raw_dataset.py
+++ b/input_generator/raw_dataset.py
@@ -306,10 +306,11 @@ class SampleCollection:
             )
             return
         else:
-            cg_coords, cg_forces = slice_coord_forces(
+            cg_coords, cg_forces, force_map = slice_coord_forces(
                 coords, forces, self.cg_map, mapping, force_stride
             )
 
+            self.force_map = force_map
             self.cg_coords = cg_coords
             self.cg_forces = cg_forces
 
@@ -319,6 +320,7 @@ class SampleCollection:
         self,
         save_dir: str,
         save_coord_force: bool = True,
+        save_cg_maps: bool = True,
         cg_coords: Union[np.ndarray, None] = None,
         cg_forces: Union[np.ndarray, None] = None,
     ):
@@ -371,6 +373,22 @@ class SampleCollection:
                     np.save(f"{save_templ}cg_forces.npy", self.cg_forces)
             else:
                 np.save(f"{save_templ}cg_forces.npy", cg_forces)
+
+        if save_cg_maps:
+            if not hasattr(self, "cg_map"):
+                print(
+                    "No cg coordinate map found. Skipping save."
+                )
+            else:
+                np.save(f"{save_templ}cg_coord_map.npy", self.cg_map)
+
+            if not hasattr(self, "force_map"):
+                print(
+                    "No cg force map found. Skipping save."
+                )
+            else:
+                np.save(f"{save_templ}cg_force_map.npy", self.cg_map)
+
 
     def get_prior_nls(
         self, prior_builders: List[PriorBuilder], save_nls: bool = True, **kwargs

--- a/input_generator/raw_dataset.py
+++ b/input_generator/raw_dataset.py
@@ -387,7 +387,7 @@ class SampleCollection:
                     "No cg force map found. Skipping save."
                 )
             else:
-                np.save(f"{save_templ}cg_force_map.npy", self.cg_map)
+                np.save(f"{save_templ}cg_force_map.npy", self.force_map)
 
 
     def get_prior_nls(

--- a/input_generator/utils.py
+++ b/input_generator/utils.py
@@ -11,9 +11,6 @@ from aggforce import (LinearMap,
                     qp_linear_map
                     )
 
-# aggforce import linearmap as lm
-# aggforce import agg as ag
-# aggforce import constfinder as cf
 
 from .prior_gen import PriorBuilder
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
-#-e git:https://github.com/noegroup/aggforce-legacy.git@1a93ef4ddafd2f8a9fc77eabfa4bdd2e2d516880#egg=aggforce
-aggforce @ git+https://github.com/noegroup/aggforce-legacy.git -e
+aggforce @ git+https://github.com/noegroup/aggforce.git -e
 h5py
 jsonargparse
 matplotlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,17 @@
+#-e git:https://github.com/noegroup/aggforce-legacy.git@1a93ef4ddafd2f8a9fc77eabfa4bdd2e2d516880#egg=aggforce
+aggforce @ git+https://github.com/noegroup/aggforce-legacy.git -e
+h5py
+jsonargparse
+matplotlib
+mdtraj
+mlcg @ git+https://github.com/ClementiGroup/mlcg.git@0.0.1 -e
+natsort
+networkx
+numpy 
+pandas
+PyYAML
+scikit-learn
+SciPy
+torch
+torch_geometric
+tqdm

--- a/scripts/gen_input_data.py
+++ b/scripts/gen_input_data.py
@@ -89,8 +89,8 @@ def process_raw_dataset(
             aa_coords, aa_forces, mapping=cg_mapping_strategy
         )
 
-        samples.save_cg_output(save_dir, save_coord_force=True)
-        # the sample object will retain the output so it makes sense to cut them 
+        samples.save_cg_output(save_dir, save_coord_force=True, save_cg_maps=True)
+        # the sample object will retain the output so it makes sense to delete them 
         del samples.cg_coords
         del samples.cg_forces
         

--- a/scripts/produce_delta_forces.py
+++ b/scripts/produce_delta_forces.py
@@ -20,7 +20,6 @@ from time import ctime
 
 from typing import Dict, List, Union, Callable, Optional
 from jsonargparse import CLI
-from repulsion_fitted import Repulsion
 
 def produce_delta_forces(
     dataset_name: str,


### PR DESCRIPTION
Currently, we rely on using the aggforce package in an outdated version for getting optimized force mappings. The current pull request makes changes to the API so that we can use the latest version of the package. Other minor fixes include:

* Added functionality to save both the coordinate map and the force map. For now it is hard-coded to save them but it's easy to make this an optional parameter in the yamls.
* Add a requirements.txt file so that we can run pip over it to install packages such as aggforce, mlcg and natsort before having a dependency problem. 
* Add docstrings for `DatasetLoader` . I think its useful as this is an important class in the code. 
* Remove some outdated parameters in the trpcage yaml examples.