### PR TITLE
Bugfix/examples

### DIFF
--- a/examples/trpcage.yaml
+++ b/examples/trpcage.yaml
@@ -16,5 +16,4 @@ embedding_func: input_generator.embedding_fivebead
 skip_residues:
 - ACE
 - NME
-use_terminal_embeddings: false
 cg_mapping_strategy: slice_aggregate

--- a/examples/trpcage_delta_forces.yaml
+++ b/examples/trpcage_delta_forces.yaml
@@ -5,4 +5,4 @@ save_dir: /path/to/output/directory/
 prior_tag: prior_tag
 prior_fn: /path/to/prior/model/prior_tag_prior_model.pt
 batch_size: 10000
-device: cuda
+device: cpu

--- a/examples/trpcage_delta_forces.yaml
+++ b/examples/trpcage_delta_forces.yaml
@@ -2,7 +2,7 @@ dataset_name: 2JOF
 names: [2JOF]
 tag: ""
 save_dir: /path/to/output/directory/
-prior_tag: cgschnet
-prior_fn: /path/to/prior/model/prior_model.pt
+prior_tag: prior_tag
+prior_fn: /path/to/prior/model/prior_tag_prior_model.pt
 batch_size: 10000
 device: cuda

--- a/examples/trpcage_packaging.yaml
+++ b/examples/trpcage_packaging.yaml
@@ -1,6 +1,8 @@
 dataset_name: 2JOF
 names: [2JOF]
 training_data_dir: /path/to/training/data/directory/
-force_tag: ""
+force_tag: "prior_tag"
 dataset_tag: ""
 save_dir: /path/to/output/directory/
+single_protein: True
+train_size: 0.8

--- a/input_generator/raw_data_loader.py
+++ b/input_generator/raw_data_loader.py
@@ -7,6 +7,7 @@ from typing import Tuple
 import mdtraj as md
 import warnings
 from pathlib import Path
+from tqdm import tqdm
 
 class DatasetLoader:
     pass
@@ -148,7 +149,7 @@ class Trpcage_loader(DatasetLoader):
         return aa_traj, top_dataframe
 
     def load_coords_forces(
-        self, base_dir: str, name: str
+        self, base_dir: str, name: str, stride: int = 1,
     ) -> Tuple[np.ndarray, np.ndarray]:
         """
         For a given name, returns np.ndarray's of its coordinates and forces at
@@ -177,13 +178,13 @@ class Trpcage_loader(DatasetLoader):
         aa_coord_list = []
         aa_force_list = []
         # load the files, checking against the mol dictionary
-        for cfn, ffn in zip(coords_fns, forces_fns):
+        for cfn, ffn in tqdm(zip(coords_fns, forces_fns), total=len(coords_fns)):
             force = np.load(ffn)  # in AA
             coord = np.load(cfn)  # in kcal/mol/AA
 
             assert coord.shape == force.shape
-            aa_coord_list.append(coord)
-            aa_force_list.append(force)
+            aa_coord_list.append(coord[::stride])
+            aa_force_list.append(force[::stride])
         aa_coords = np.concatenate(aa_coord_list)
         aa_forces = np.concatenate(aa_force_list)
         return aa_coords, aa_forces
@@ -199,7 +200,7 @@ class Cln_loader(DatasetLoader):
         return aa_traj, top_dataframe
 
     def load_coords_forces(
-        self, base_dir: str, name: str
+        self, base_dir: str, name: str, stride: int = 1,
     ) -> Tuple[np.ndarray, np.ndarray]:
         coords_fns = natsorted(
             glob(os.path.join(base_dir, f"coords_nowater/chig_coor_*.npy"))
@@ -213,13 +214,13 @@ class Cln_loader(DatasetLoader):
         aa_coord_list = []
         aa_force_list = []
         # load the files, checking against the mol dictionary
-        for cfn, ffn in zip(coords_fns, forces_fns):
+        for cfn, ffn in tqdm(zip(coords_fns, forces_fns), total=len(coords_fns)):
             force = np.load(ffn)  # in AA
             coord = np.load(cfn)  # in kcal/mol/AA
 
             assert coord.shape == force.shape
-            aa_coord_list.append(coord)
-            aa_force_list.append(force)
+            aa_coord_list.append(coord[::stride])
+            aa_force_list.append(force[::stride])
         aa_coords = np.concatenate(aa_coord_list)
         aa_forces = np.concatenate(aa_force_list)
         return aa_coords, aa_forces
@@ -235,7 +236,7 @@ class Villin_loader(DatasetLoader):
         return aa_traj, top_dataframe
     
     def load_coords_forces(
-            self, base_dir: str, name: str
+            self, base_dir: str, name: str, stride: int = 1,
     ) -> Tuple[np.ndarray, np.ndarray]:
         coords_fns = sorted(
             glob(
@@ -251,13 +252,13 @@ class Villin_loader(DatasetLoader):
 
         aa_coord_list = []
         aa_force_list = []
-        for c, f in zip(coords_fns, forces_fns):
+        for c, f in tqdm(zip(coords_fns, forces_fns), total=len(coords_fns)):
             coords = np.load(c)
             forces = np.load(f)
             assert coords.shape == forces.shape
 
-            aa_coord_list.append(coords)
-            aa_force_list.append(forces)
+            aa_coord_list.append(coords[::stride])
+            aa_force_list.append(forces[::stride])
         
         aa_coords = np.concatenate(aa_coord_list)
         aa_forces = np.concatenate(aa_force_list)
@@ -289,7 +290,7 @@ class OPEP_loader(DatasetLoader):
         return aa_traj, top_dataframe
 
     def load_coords_forces(
-        self, base_dir: str, name: str
+        self, base_dir: str, name: str, stride: int = 1,
     ) -> Tuple[np.ndarray, np.ndarray]:
         """
         For a given CATH domain name, returns np.ndarray's of its coordinates and forces at
@@ -302,15 +303,15 @@ class OPEP_loader(DatasetLoader):
         name:
             Name of input sample
         """
-        coord_files = sorted(glob(f"{base_dir}coords_nowater/opep_{name}/*.npy"))
+        coord_files = sorted(glob(os.path.join(base_dir, f"coords_nowater/opep_{name}/*.npy")))
         if len(coord_files) == 0:
             coord_files = sorted(
-                glob(f"{base_dir}coords_nowater/coor_opep_{name}_*.npy")
+                glob(os.path.join(base_dir, f"coords_nowater/coor_opep_{name}_*.npy"))
             )
-        force_files = sorted(glob(f"{base_dir}forces_nowater/opep_{name}/*.npy"))
+        force_files = sorted(glob(os.path.join(base_dir, f"forces_nowater/opep_{name}/*.npy")))
         if len(force_files) == 0:
             force_files = sorted(
-                glob(f"{base_dir}forces_nowater/force_opep_{name}_*.npy")
+                glob(os.path.join(base_dir, f"forces_nowater/force_opep_{name}_*.npy"))
             )
 
         aa_coord_list = []
@@ -318,8 +319,8 @@ class OPEP_loader(DatasetLoader):
         for c, f in zip(coord_files, force_files):
             coords = np.load(c)
             forces = np.load(f)
-            aa_coord_list.append(coords)
-            aa_force_list.append(forces)
+            aa_coord_list.append(coords[::stride])
+            aa_force_list.append(forces[::stride])
         aa_coords = np.concatenate(aa_coord_list)
         aa_forces = np.concatenate(aa_force_list)
         return aa_coords, aa_forces

--- a/scripts/package_training_data.py
+++ b/scripts/package_training_data.py
@@ -79,7 +79,7 @@ def package_training_data(
 
     if save_h5:
         # Create H5 of training data
-        fnout_h5 = osp.join(save_dir, f"{output_tag}.h5")
+        fnout_h5 = osp.join(save_dir, f"{output_tag[1:]}.h5")
 
         with h5py.File(fnout_h5, "w") as f:
             metaset = f.create_group(dataset_name)

--- a/scripts/produce_delta_forces.py
+++ b/scripts/produce_delta_forces.py
@@ -20,7 +20,6 @@ from time import ctime
 
 from typing import Dict, List, Union, Callable, Optional
 from jsonargparse import CLI
-from repulsion_fitted import Repulsion
 
 def produce_delta_forces(
     dataset_name: str,
@@ -70,7 +69,10 @@ def produce_delta_forces(
 
         num_frames = coords.shape[0]
         delta_forces = []
-        for i in range(0, num_frames, batch_size):
+        iterator = range(0, num_frames, batch_size)
+        if len(names) == 1:
+            iterator = tqdm(iterator)
+        for i in iterator:
             sub_data_list = []
             for j in range(batch_size):
                 if i + j < len(coords):


### PR DESCRIPTION
This PR fixes bugs in the example trpcage pipeline since the pipeline was mostly tested on transferable multi-molecule datasets, and adds some small additional features.

In particular:
- the packaging script now works for a single protein 
- a tqdm bar now appears for single-protein delta-force generation to avoid having to wait in the dark for 2,5 hours 
- the loaders for single-protein datasets (larger than a single CATH molecule) also now have a tqdm bar 