### PR TITLE
Trajectory loading in batches

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -39,7 +39,7 @@ If your program gets killed after the loading of the all-atom data succeeded (tq
 
 ##### Batch processing for large datasets:
 
-Should your dataset be too big to be loaded into memory at once (the tqdm bar doesn't finish before it fails), you can set the `traj_num_batches` in your `trpcage.yaml` file as well as your `trpcage_stats.yaml`, `trpcage_delta_forces.yaml` and `trpcage_packaging.yaml` file. This will seperate the trajectories in your dataset into `traj_num_batches` chunks that will be treated as separate molecules for the coarse-graining and statistics computing stages (see 2 below) and the statistics of the different batches will be automatically accumulated to get only one prior object in the end. Note that in this case, the force map will be only computed on the first batch and re-used for all subsequent batches to ensure consistency in the case of optimized force maps.
+Should your dataset be too big to be loaded into memory at once (the tqdm bar doesn't finish before it fails), you can set the `mol_num_batches` in your `trpcage.yaml` file as well as your `trpcage_stats.yaml`, `trpcage_delta_forces.yaml` and `trpcage_packaging.yaml` file. This will seperate the trajectories in your dataset into `mol_num_batches` chunks that will be treated as separate molecules for the coarse-graining and statistics computing stages (see 2 below) and the statistics of the different batches will be automatically accumulated to get only one prior object in the end. Note that in this case, the force map will be only computed on the first batch and re-used for all subsequent batches to ensure consistency in the case of optimized force maps.
 
 #### 2) Computing statistics and fitting priors
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -37,7 +37,9 @@ Note if you are using a custom dataset:
 
 If your program gets killed after the loading of the all-atom data succeeded (tqdm bar finished) but before `process_raw_dataset` saved the CG output, try to set `batch_size` in your `trpcage.yaml` file. This will batch the matrix multiplication between atomistic coordinates/forces, which is the most memory-consuming part of the coarse-graining at this stage.
 
-Should your dataset be too big to be loaded into memory at once (the tqdm bar doesn't finish before it fails), you can set the `traj_num_batches` in your `trpcage.yaml` file as well as your `trpcage_stats.yaml` file. This will seperate the trajectories in your dataset into `traj_num_batches` chunks that will be treated as separate molecules for the coarse-graining and statistics computing stages (see 2 below) and the statistics of the different batches will be automatically accumulated to get only one prior object in the end. Note that in this case, the force map will be only computed on the first batch and re-used for all subsequent batches to ensure consistency in the case of optimized force maps.
+##### Batch processing for large datasets:
+
+Should your dataset be too big to be loaded into memory at once (the tqdm bar doesn't finish before it fails), you can set the `traj_num_batches` in your `trpcage.yaml` file as well as your `trpcage_stats.yaml`, `trpcage_delta_forces.yaml` and `trpcage_packaging.yaml` file. This will seperate the trajectories in your dataset into `traj_num_batches` chunks that will be treated as separate molecules for the coarse-graining and statistics computing stages (see 2 below) and the statistics of the different batches will be automatically accumulated to get only one prior object in the end. Note that in this case, the force map will be only computed on the first batch and re-used for all subsequent batches to ensure consistency in the case of optimized force maps.
 
 #### 2) Computing statistics and fitting priors
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -37,7 +37,7 @@ Note if you are using a custom dataset:
 
 If your program gets killed after the loading of the all-atom data succeeded (tqdm bar finished) but before `process_raw_dataset` saved the CG output, try to set `batch_size` in your `trpcage.yaml` file. This will batch the matrix multiplication between atomistic coordinates/forces, which is the most memory-consuming part of the coarse-graining at this stage.
 
-Should your dataset be too big to be loaded into memory at once (the tqdm bar doesn't finish before it fails), you can set the `traj_num_batches` in your `trpcage.yaml` file as well as your `trpcage_stats.yaml` file. This will seperate the trajectories in your dataset into `traj_num_batches` chunks that will be treated as separate molecules for the coarse-graining and statistics computing stages (see 2 below) and the statistics of the different batches will be automatically accumulated to get only one prior object in the end.
+Should your dataset be too big to be loaded into memory at once (the tqdm bar doesn't finish before it fails), you can set the `traj_num_batches` in your `trpcage.yaml` file as well as your `trpcage_stats.yaml` file. This will seperate the trajectories in your dataset into `traj_num_batches` chunks that will be treated as separate molecules for the coarse-graining and statistics computing stages (see 2 below) and the statistics of the different batches will be automatically accumulated to get only one prior object in the end. Note that in this case, the force map will be only computed on the first batch and re-used for all subsequent batches to ensure consistency in the case of optimized force maps.
 
 #### 2) Computing statistics and fitting priors
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -33,6 +33,12 @@ This procedure will loop over all of the sample names specified by the `names` o
 
 Keep in mind that the priors are assumed to be in [kcal/mol] at the fitting stage so raw forces should be transformed to [kcal/mol/angstrom].
 
+Note if you are using a custom dataset:
+
+If your program gets killed after the loading of the all-atom data succeeded (tqdm bar finished) but before `process_raw_dataset` saved the CG output, try to set `batch_size` in your `trpcage.yaml` file. This will batch the matrix multiplication between atomistic coordinates/forces, which is the most memory-consuming part of the coarse-graining at this stage.
+
+Should your dataset be too big to be loaded into memory at once (the tqdm bar doesn't finish before it fails), you can set the `traj_num_batches` in your `trpcage.yaml` file as well as your `trpcage_stats.yaml` file. This will seperate the trajectories in your dataset into `traj_num_batches` chunks that will be treated as separate molecules for the coarse-graining and statistics computing stages (see 2 below) and the statistics of the different batches will be automatically accumulated to get only one prior object in the end.
+
 #### 2) Computing statistics and fitting priors
 
 Command:

--- a/input_generator/__init__.py
+++ b/input_generator/__init__.py
@@ -5,6 +5,7 @@ from .raw_data_loader import (
     Villin_loader,
     Trpcage_loader,
     Cln_loader,
+    BBA_loader,
     OPEP_loader,
 )
 

--- a/input_generator/raw_data_loader.py
+++ b/input_generator/raw_data_loader.py
@@ -68,6 +68,11 @@ class DatasetLoader:
             Name of input sample
         stride : int
             Interval by which to stride loaded data
+        batch: int or None
+            if trajectories are loaded by batch, indicates the batch index to load
+            must be set if n_batches > 1
+        n_batches: int
+            if greater than 1, divide the total trajectories to load into n_batches chunks
         """
         raise NotImplementedError(f"Base class {self.__class__} has no implementation")
 
@@ -116,6 +121,11 @@ class CATH_loader(DatasetLoader):
             Name of input sample
         stride : int
             Interval by which to stride loaded data
+        batch: int or None
+            if trajectories are loaded by batch, indicates the batch index to load
+            must be set if n_batches > 1
+        n_batches: int
+            if greater than 1, divide the total trajectories to load into n_batches chunks
         """
 
         outputs_fns = natsorted(glob(os.path.join(base_dir, f"output/{name}/*_part_*")))
@@ -184,6 +194,11 @@ class DIMER_loader(DatasetLoader):
             Name of input sample
         stride : int
             Interval by which to stride loaded data
+        batch: int or None
+            if trajectories are loaded by batch, indicates the batch index to load
+            must be set if n_batches > 1
+        n_batches: int
+            if greater than 1, divide the total trajectories to load into n_batches chunks
         """
         if n_batches > 1:
             raise NotImplementedError("traj_n_batches can only be used for single-protein datasets for now")
@@ -242,6 +257,13 @@ class Trpcage_loader(DatasetLoader):
             Path to coordinate and force files
         name:
             Name of input sample
+        stride : int
+            Interval by which to stride loaded data
+        batch: int or None
+            if trajectories are loaded by batch, indicates the batch index to load
+            must be set if n_batches > 1
+        n_batches: int
+            if greater than 1, divide the total trajectories to load into n_batches chunks
         """
         coords_fns = natsorted(
             glob(
@@ -297,6 +319,24 @@ class Cln_loader(DatasetLoader):
         batch: Optional[int] = None, 
         n_batches: Optional[int] = 1
     ) -> Tuple[np.ndarray, np.ndarray]:
+        """
+        For a given name, returns np.ndarray's of its coordinates and forces at
+        the input resolution (generally atomistic)
+
+        Parameters
+        ----------
+        base_dir:
+            Path to coordinate and force files
+        name:
+            Name of input sample
+        stride : int
+            Interval by which to stride loaded data
+        batch: int or None
+            if trajectories are loaded by batch, indicates the batch index to load
+            must be set if n_batches > 1
+        n_batches: int
+            if greater than 1, divide the total trajectories to load into n_batches chunks
+        """
         coords_fns = natsorted(
             glob(os.path.join(base_dir, f"coords_nowater/chig_coor_*.npy"))
         )
@@ -371,6 +411,13 @@ class BBA_loader(DatasetLoader):
             Path to coordinate and force files
         name:
             Name of input sample
+        stride : int
+            Interval by which to stride loaded data
+        batch: int or None
+            if trajectories are loaded by batch, indicates the batch index to load
+            must be set if n_batches > 1
+        n_batches: int
+            if greater than 1, divide the total trajectories to load into n_batches chunks
         """
         coords_fns = natsorted(
             glob(
@@ -425,6 +472,24 @@ class Villin_loader(DatasetLoader):
         batch: Optional[int] = None, 
         n_batches: Optional[int] = 1
     ) -> Tuple[np.ndarray, np.ndarray]:
+        """
+        For a given name, returns np.ndarray's of its coordinates and forces at
+        the input resolution (generally atomistic)
+
+        Parameters
+        ----------
+        base_dir:
+            Path to coordinate and force files
+        name:
+            Name of input sample
+        stride : int
+            Interval by which to stride loaded data
+        batch: int or None
+            if trajectories are loaded by batch, indicates the batch index to load
+            must be set if n_batches > 1
+        n_batches: int
+            if greater than 1, divide the total trajectories to load into n_batches chunks
+        """
         coords_fns = sorted(
             glob(
                 os.path.join(base_dir, f"{name}/*_coords.npy")
@@ -494,7 +559,7 @@ class OPEP_loader(DatasetLoader):
         n_batches: Optional[int] = 1
     ) -> Tuple[np.ndarray, np.ndarray]:
         """
-        For a given CATH domain name, returns np.ndarray's of its coordinates and forces at
+        For a given name, returns np.ndarray's of its coordinates and forces at
         the input resolution (generally atomistic)
 
         Parameters
@@ -503,6 +568,13 @@ class OPEP_loader(DatasetLoader):
             Path to coordinate and force files
         name:
             Name of input sample
+        stride : int
+            Interval by which to stride loaded data
+        batch: int or None
+            if trajectories are loaded by batch, indicates the batch index to load
+            must be set if n_batches > 1
+        n_batches: int
+            if greater than 1, divide the total trajectories to load into n_batches chunks
         """
         if n_batches > 1:
             raise NotImplementedError("traj_n_batches can only be used for single-protein datasets for now")

--- a/input_generator/raw_data_loader.py
+++ b/input_generator/raw_data_loader.py
@@ -278,6 +278,70 @@ class Cln_loader(DatasetLoader):
         aa_forces = np.concatenate(aa_force_list)
         return aa_coords, aa_forces
 
+class BBA_loader(DatasetLoader):
+    """
+    Loader object for CHARMM22* BBA simulation dataset
+    """
+
+    def get_traj_top(self, name: str, pdb_fn: str):
+        """
+        For a given name, returns a loaded MDTraj object at the input resolution
+        (generally atomistic) as well as the dataframe associated with its topology.
+
+        Parameters
+        ----------
+        name:
+            Name of input sample
+        pdb_fn:
+            Path to pdb structure file
+        """
+        pdb = md.load(pdb_fn.format(name))
+        aa_traj = pdb.atom_slice(
+            [a.index for a in pdb.topology.atoms if a.residue.is_protein]
+        )
+        top_dataframe = aa_traj.topology.to_dataframe()[0]
+        return aa_traj, top_dataframe
+
+    def load_coords_forces(
+        self, base_dir: str, name: str,  stride: int = 1
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        """
+        For a given name, returns np.ndarray's of its coordinates and forces at
+        the input resolution (generally atomistic)
+
+        Parameters
+        ----------
+        base_dir:
+            Path to coordinate and force files
+        name:
+            Name of input sample
+        """
+        coords_fns = natsorted(
+            glob(
+                os.path.join(base_dir, f"coords_nowater/bba_coor_folding-bba_*.npy")
+            )
+        )
+
+        forces_fns = [
+            fn.replace(
+                "coords_nowater/bba_coor_folding", "forces_nowater/bba_force_folding"
+            )
+            for fn in coords_fns
+        ]
+
+        aa_coord_list = []
+        aa_force_list = []
+        # load the files, checking against the mol dictionary
+        for cfn, ffn in tqdm(zip(coords_fns, forces_fns), total=len(coords_fns)):
+            force = np.load(ffn)  # in AA
+            coord = np.load(cfn)  # in kcal/mol/AA
+
+            assert coord.shape == force.shape
+            aa_coord_list.append(coord[::stride])
+            aa_force_list.append(force[::stride])
+        aa_coords = np.concatenate(aa_coord_list)
+        aa_forces = np.concatenate(aa_force_list)
+        return aa_coords, aa_forces
 
 class Villin_loader(DatasetLoader):
     def get_traj_top(self, name: str, pdb_fn: str):

--- a/input_generator/raw_data_loader.py
+++ b/input_generator/raw_data_loader.py
@@ -131,7 +131,7 @@ class CATH_loader(DatasetLoader):
         outputs_fns = natsorted(glob(os.path.join(base_dir, f"output/{name}/*_part_*")))
 
         if n_batches > 1:
-            raise NotImplementedError("traj_n_batches can only be used for single-protein datasets for now")
+            raise NotImplementedError("mol_num_batches can only be used for single-protein datasets for now")
 
         aa_coord_list = []
         aa_force_list = []
@@ -201,7 +201,7 @@ class DIMER_loader(DatasetLoader):
             if greater than 1, divide the total trajectories to load into n_batches chunks
         """
         if n_batches > 1:
-            raise NotImplementedError("traj_n_batches can only be used for single-protein datasets for now")
+            raise NotImplementedError("mol_num_batches can only be used for single-protein datasets for now")
 
         with h5py.File(os.path.join(base_dir, "allatom.h5"), "r") as data:
             coord = data["MINI"][name]["aa_coords"][:][::stride]
@@ -577,7 +577,7 @@ class OPEP_loader(DatasetLoader):
             if greater than 1, divide the total trajectories to load into n_batches chunks
         """
         if n_batches > 1:
-            raise NotImplementedError("traj_n_batches can only be used for single-protein datasets for now")
+            raise NotImplementedError("mol_num_batches can only be used for single-protein datasets for now")
 
         coord_files = sorted(glob(os.path.join(base_dir, f"coords_nowater/opep_{name}/*.npy")))
         if len(coord_files) == 0:

--- a/input_generator/raw_data_loader.py
+++ b/input_generator/raw_data_loader.py
@@ -3,11 +3,12 @@ import os
 from natsort import natsorted
 from glob import glob
 import h5py
-from typing import Tuple
+from typing import Tuple, Optional
 import mdtraj as md
 import warnings
 from pathlib import Path
 from tqdm import tqdm
+from .utils import chunker
 
 class DatasetLoader:
     r"""
@@ -45,7 +46,12 @@ class DatasetLoader:
         raise NotImplementedError(f"Base class {self.__class__} has no implementation")
     
     def load_coords_forces(
-        self, base_dir: str, name: str, stride: int = 1,
+        self, 
+        base_dir: str, 
+        name: str,  
+        stride: int = 1, 
+        batch: Optional[int] = None, 
+        n_batches: Optional[int] = 1
     ) -> Tuple[np.ndarray, np.ndarray]:
         r"""
         Method to load the coordinate and force data
@@ -91,7 +97,12 @@ class CATH_loader(DatasetLoader):
         return aa_traj, top_dataframe
 
     def load_coords_forces(
-        self, base_dir: str, name: str, stride: int = 1,
+        self, 
+        base_dir: str, 
+        name: str,  
+        stride: int = 1, 
+        batch: Optional[int] = None, 
+        n_batches: Optional[int] = 1
     ) -> Tuple[np.ndarray, np.ndarray]:
         """
         For a given CATH domain name, returns np.ndarray's of its coordinates and forces at
@@ -106,8 +117,12 @@ class CATH_loader(DatasetLoader):
         stride : int
             Interval by which to stride loaded data
         """
-        # return sorted(name, key=alphanum_key)
+
         outputs_fns = natsorted(glob(os.path.join(base_dir, f"output/{name}/*_part_*")))
+
+        if n_batches > 1:
+            raise NotImplementedError("traj_n_batches can only be used for single-protein datasets for now")
+
         aa_coord_list = []
         aa_force_list = []
         # load the files, checking against the mol dictionary
@@ -150,7 +165,12 @@ class DIMER_loader(DatasetLoader):
         return aa_traj, top_dataframe
 
     def load_coords_forces(
-        self, base_dir: str, name: str, stride: int = 1,
+        self, 
+        base_dir: str, 
+        name: str,  
+        stride: int = 1, 
+        batch: Optional[int] = None, 
+        n_batches: Optional[int] = 1
     ) -> Tuple[np.ndarray, np.ndarray]:
         """
         For a given DIMER pair name, returns np.ndarray's of its coordinates and forces at
@@ -165,6 +185,9 @@ class DIMER_loader(DatasetLoader):
         stride : int
             Interval by which to stride loaded data
         """
+        if n_batches > 1:
+            raise NotImplementedError("traj_n_batches can only be used for single-protein datasets for now")
+
         with h5py.File(os.path.join(base_dir, "allatom.h5"), "r") as data:
             coord = data["MINI"][name]["aa_coords"][:][::stride]
             force = data["MINI"][name]["aa_forces"][:][::stride]
@@ -202,7 +225,12 @@ class Trpcage_loader(DatasetLoader):
         return aa_traj, top_dataframe
 
     def load_coords_forces(
-        self, base_dir: str, name: str,  stride: int = 1
+        self, 
+        base_dir: str, 
+        name: str,  
+        stride: int = 1, 
+        batch: Optional[int] = None, 
+        n_batches: Optional[int] = 1
     ) -> Tuple[np.ndarray, np.ndarray]:
         """
         For a given name, returns np.ndarray's of its coordinates and forces at
@@ -227,6 +255,15 @@ class Trpcage_loader(DatasetLoader):
             )
             for fn in coords_fns
         ]
+
+        coords_fns = np.array(coords_fns)
+        forces_fns = np.array(forces_fns)
+
+        if n_batches > 1:
+            assert batch is not None, "batch id must be set if more than 1 batch"
+            chunk_ids = chunker([i for i in range(len(coords_fns))], n_batches=n_batches)
+            coords_fns = coords_fns[np.array(chunk_ids[batch])]
+            forces_fns = forces_fns[np.array(chunk_ids[batch])]
 
         aa_coord_list = []
         aa_force_list = []
@@ -253,7 +290,12 @@ class Cln_loader(DatasetLoader):
         return aa_traj, top_dataframe
 
     def load_coords_forces(
-        self, base_dir: str, name: str, stride: int = 1
+        self, 
+        base_dir: str, 
+        name: str,  
+        stride: int = 1, 
+        batch: Optional[int] = None, 
+        n_batches: Optional[int] = 1
     ) -> Tuple[np.ndarray, np.ndarray]:
         coords_fns = natsorted(
             glob(os.path.join(base_dir, f"coords_nowater/chig_coor_*.npy"))
@@ -263,6 +305,15 @@ class Cln_loader(DatasetLoader):
             fn.replace("coords_nowater/chig_coor_", "forces_nowater/chig_force_")
             for fn in coords_fns
         ]
+
+        coords_fns = np.array(coords_fns)
+        forces_fns = np.array(forces_fns)
+
+        if n_batches > 1:
+            assert batch is not None, "batch id must be set if more than 1 batch"
+            chunk_ids = chunker([i for i in range(len(coords_fns))], n_batches=n_batches)
+            coords_fns = coords_fns[np.array(chunk_ids[batch])]
+            forces_fns = forces_fns[np.array(chunk_ids[batch])]
 
         aa_coord_list = []
         aa_force_list = []
@@ -303,7 +354,12 @@ class BBA_loader(DatasetLoader):
         return aa_traj, top_dataframe
 
     def load_coords_forces(
-        self, base_dir: str, name: str,  stride: int = 1
+        self, 
+        base_dir: str, 
+        name: str,  
+        stride: int = 1, 
+        batch: Optional[int] = None, 
+        n_batches: Optional[int] = 1
     ) -> Tuple[np.ndarray, np.ndarray]:
         """
         For a given name, returns np.ndarray's of its coordinates and forces at
@@ -329,6 +385,15 @@ class BBA_loader(DatasetLoader):
             for fn in coords_fns
         ]
 
+        coords_fns = np.array(coords_fns)
+        forces_fns = np.array(forces_fns)
+
+        if n_batches > 1:
+            assert batch is not None, "batch id must be set if more than 1 batch"
+            chunk_ids = chunker([i for i in range(len(coords_fns))], n_batches=n_batches)
+            coords_fns = coords_fns[np.array(chunk_ids[batch])]
+            forces_fns = forces_fns[np.array(chunk_ids[batch])]
+
         aa_coord_list = []
         aa_force_list = []
         # load the files, checking against the mol dictionary
@@ -353,7 +418,12 @@ class Villin_loader(DatasetLoader):
         return aa_traj, top_dataframe
     
     def load_coords_forces(
-            self, base_dir: str, name: str, stride: int =1,
+        self, 
+        base_dir: str, 
+        name: str,  
+        stride: int = 1, 
+        batch: Optional[int] = None, 
+        n_batches: Optional[int] = 1
     ) -> Tuple[np.ndarray, np.ndarray]:
         coords_fns = sorted(
             glob(
@@ -366,6 +436,15 @@ class Villin_loader(DatasetLoader):
                 os.path.join(base_dir, f"{name}/*_forces.npy")
             )
         )
+
+        coords_fns = np.array(coords_fns)
+        forces_fns = np.array(forces_fns)
+
+        if n_batches > 1:
+            assert batch is not None, "batch id must be set if more than 1 batch"
+            chunk_ids = chunker([i for i in range(len(coords_fns))], n_batches=n_batches)
+            coords_fns = coords_fns[np.array(chunk_ids[batch])]
+            forces_fns = forces_fns[np.array(chunk_ids[batch])]
 
         aa_coord_list = []
         aa_force_list = []
@@ -407,7 +486,12 @@ class OPEP_loader(DatasetLoader):
         return aa_traj, top_dataframe
 
     def load_coords_forces(
-        self, base_dir: str, name: str, stride: int = 1,
+        self, 
+        base_dir: str, 
+        name: str,  
+        stride: int = 1, 
+        batch: Optional[int] = None, 
+        n_batches: Optional[int] = 1
     ) -> Tuple[np.ndarray, np.ndarray]:
         """
         For a given CATH domain name, returns np.ndarray's of its coordinates and forces at
@@ -420,6 +504,9 @@ class OPEP_loader(DatasetLoader):
         name:
             Name of input sample
         """
+        if n_batches > 1:
+            raise NotImplementedError("traj_n_batches can only be used for single-protein datasets for now")
+
         coord_files = sorted(glob(os.path.join(base_dir, f"coords_nowater/opep_{name}/*.npy")))
         if len(coord_files) == 0:
             coord_files = sorted(

--- a/input_generator/raw_dataset.py
+++ b/input_generator/raw_dataset.py
@@ -710,14 +710,14 @@ class SampleCollection:
         self, 
         training_data_dir: str, 
         force_tag: str = "", 
-        traj_n_batches: int = 1,
+        mol_num_batches: int = 1,
         stride: int = 1
     ):
         mol_save_templ = os.path.join(training_data_dir, get_output_tag([self.tag, self.name], placement="before"))
         cg_embeds = np.load(f"{mol_save_templ}cg_embeds.npy")
         cg_coords = []
         cg_forces = []
-        for b in range(traj_n_batches):
+        for b in range(mol_num_batches):
             save_templ = os.path.join(training_data_dir, get_output_tag([self.tag, self.name, f"batch_{b}"], placement="before"))
             save_templ_forces = os.path.join(training_data_dir, get_output_tag([self.tag, self.name, f"batch_{b}", force_tag], placement="before"))
 

--- a/input_generator/raw_dataset.py
+++ b/input_generator/raw_dataset.py
@@ -429,6 +429,7 @@ class SampleCollection:
                 np.save(f"{save_templ}cg_forces.npy", cg_forces)
 
         if save_cg_maps:
+            map_save_templ = os.path.join(save_dir, get_output_tag([self.tag, self.mol_name], placement="before"))
             if not hasattr(self, "cg_map"):
                 warnings.warn(
                     "No cg coordinate map found. Skipping save."
@@ -441,7 +442,28 @@ class SampleCollection:
                     "No cg force map found. Skipping save."
                 )
             else:
-                np.save(f"{save_templ}cg_force_map.npy", self.force_map)
+                np.save(f"{map_save_templ}cg_force_map.npy", self.force_map)
+
+    def load_cg_force_map(
+        self,
+        save_dir: str
+    ) -> np.ndarray:
+        """
+        Helper function to load a previously saved force map for the molecule in the sample
+
+        Parameters:
+        -----------
+        save_dir: str
+            path to the directory where the force map was saved in the first batch of the molecule in the sample
+        
+        Returns:
+        --------
+        force_map: np.ndarray
+            force map corresponding to the molecule in self
+        """
+        map_save_templ = os.path.join(save_dir, get_output_tag([self.tag, self.mol_name], placement="before"))
+        force_map = np.load(f"{map_save_templ}cg_force_map.npy")
+        return force_map
 
 
     def get_prior_nls(

--- a/input_generator/raw_dataset.py
+++ b/input_generator/raw_dataset.py
@@ -389,13 +389,14 @@ class SampleCollection:
             warnings.warn("CG mapping must be applied before outputs can be saved.")
             return
 
+        mol_save_templ = os.path.join(save_dir, get_output_tag([self.tag, self.mol_name], placement="before"))
         save_templ = os.path.join(save_dir, get_output_tag([self.tag, self.name], placement="before"))
         cg_xyz = self.input_traj.atom_slice(self.cg_atom_indices).xyz
         cg_traj = md.Trajectory(cg_xyz, md.Topology.from_dataframe(self.cg_dataframe))
-        cg_traj.save_pdb(f"{save_templ}cg_structure.pdb")
+        cg_traj.save_pdb(f"{mol_save_templ}cg_structure.pdb")
 
         embeds = np.array(self.cg_dataframe["type"].to_list())
-        np.save(f"{save_templ}cg_embeds.npy", embeds)
+        np.save(f"{mol_save_templ}cg_embeds.npy", embeds)
 
         if save_coord_force:
             if cg_coords == None:
@@ -429,20 +430,19 @@ class SampleCollection:
                 np.save(f"{save_templ}cg_forces.npy", cg_forces)
 
         if save_cg_maps:
-            map_save_templ = os.path.join(save_dir, get_output_tag([self.tag, self.mol_name], placement="before"))
             if not hasattr(self, "cg_map"):
                 warnings.warn(
                     "No cg coordinate map found. Skipping save."
                 )
             else:
-                np.save(f"{save_templ}cg_coord_map.npy", self.cg_map)
+                np.save(f"{mol_save_templ}cg_coord_map.npy", self.cg_map)
 
             if not hasattr(self, "force_map"):
                 warnings.warn(
                     "No cg force map found. Skipping save."
                 )
             else:
-                np.save(f"{map_save_templ}cg_force_map.npy", self.force_map)
+                np.save(f"{mol_save_templ}cg_force_map.npy", self.force_map)
 
     def load_cg_force_map(
         self,
@@ -621,6 +621,7 @@ class SampleCollection:
         Tuple of np.ndarrays containing coarse grained coordinates, forces, embeddings,
         structure, and prior neighbour list
         """
+        mol_save_templ = os.path.join(save_dir, get_output_tag([self.tag, self.mol_name], placement="before"))
         save_templ = os.path.join(save_dir, get_output_tag([self.tag, self.name], placement="before"))
         if os.path.exists(f"{save_templ}cg_coords.npy"):
             cg_coords = np.load(f"{save_templ}cg_coords.npy")
@@ -630,12 +631,10 @@ class SampleCollection:
             cg_forces = np.load(f"{save_templ}cg_forces.npy")
         else:
             cg_forces = None
-        cg_embeds = np.load(f"{save_templ}cg_embeds.npy")
-        cg_pdb = md.load(f"{save_templ}cg_structure.pdb")
+        cg_embeds = np.load(f"{mol_save_templ}cg_embeds.npy")
+        cg_pdb = md.load(f"{mol_save_templ}cg_structure.pdb")
         # load NLs
-        # there is only 1 nls saved per molecule, no matter how many trajectory batches
-        nls_save_templ = os.path.join(save_dir, get_output_tag([self.tag, self.mol_name], placement="before"))
-        ofile =  f"{nls_save_templ}prior_nls{get_output_tag(prior_tag, placement='after')}.pkl"
+        ofile =  f"{mol_save_templ}prior_nls{get_output_tag(prior_tag, placement='after')}.pkl"
 
         with open(ofile, "rb") as f:
             cg_prior_nls = pickle.load(f)
@@ -697,13 +696,37 @@ class SampleCollection:
         -------
         Tuple of np.ndarrays containing coarse grained coordinates, delta forces, and embeddings,
         """
+        mol_save_templ = os.path.join(training_data_dir, get_output_tag([self.tag, self.mol_name], placement="before"))
         save_templ = os.path.join(training_data_dir, get_output_tag([self.tag, self.name], placement="before"))
         cg_coords = np.load(f"{save_templ}cg_coords.npy")[::stride]
-        cg_embeds = np.load(f"{save_templ}cg_embeds.npy")
+        cg_embeds = np.load(f"{mol_save_templ}cg_embeds.npy")
 
         save_templ_forces = os.path.join(training_data_dir, get_output_tag([self.tag, self.name, force_tag], placement="before"))
         cg_forces = np.load(f"{save_templ_forces}delta_forces.npy")[::stride]
         
+        return cg_coords, cg_forces, cg_embeds
+    
+    def load_all_batches_training_inputs(
+        self, 
+        training_data_dir: str, 
+        force_tag: str = "", 
+        traj_n_batches: int = 1,
+        stride: int = 1
+    ):
+        mol_save_templ = os.path.join(training_data_dir, get_output_tag([self.tag, self.name], placement="before"))
+        cg_embeds = np.load(f"{mol_save_templ}cg_embeds.npy")
+        cg_coords = []
+        cg_forces = []
+        for b in range(traj_n_batches):
+            save_templ = os.path.join(training_data_dir, get_output_tag([self.tag, self.name, f"batch_{b}"], placement="before"))
+            save_templ_forces = os.path.join(training_data_dir, get_output_tag([self.tag, self.name, f"batch_{b}", force_tag], placement="before"))
+
+            cg_coords.append(np.load(f"{save_templ}cg_coords.npy"))
+            cg_forces.append(np.load(f"{save_templ_forces}delta_forces.npy"))
+
+        cg_coords = np.concatenate(cg_coords)[::stride]
+        cg_forces = np.concatenate(cg_forces)[::stride]
+
         return cg_coords, cg_forces, cg_embeds
 
 

--- a/input_generator/raw_dataset.py
+++ b/input_generator/raw_dataset.py
@@ -157,8 +157,16 @@ class SampleCollection:
         self,
         name: str,
         tag: str,
+        n_batches: Optional[int] = 1
     ) -> None:
         self.name = name
+        if "_batch_" in name:
+            self.mol_name = name.split("_batch_")[0]
+            self.batch = int(name.split("_batch_")[-1])
+        else:
+            self.mol_name = name
+            self.batch = None
+        self.n_batches = n_batches
         self.tag = tag
 
     def apply_cg_mapping(
@@ -603,7 +611,9 @@ class SampleCollection:
         cg_embeds = np.load(f"{save_templ}cg_embeds.npy")
         cg_pdb = md.load(f"{save_templ}cg_structure.pdb")
         # load NLs
-        ofile =  f"{save_templ}prior_nls{get_output_tag(prior_tag, placement='after')}.pkl"
+        # there is only 1 nls saved per molecule, no matter how many trajectory batches
+        nls_save_templ = os.path.join(save_dir, get_output_tag([self.tag, self.mol_name], placement="before"))
+        ofile =  f"{nls_save_templ}prior_nls{get_output_tag(prior_tag, placement='after')}.pkl"
 
         with open(ofile, "rb") as f:
             cg_prior_nls = pickle.load(f)
@@ -691,18 +701,34 @@ class RawDataset:
         List of SampleCollection objects for all samples in dataset
     """
 
-    def __init__(self, dataset_name: str, names: List[str], tag: str) -> None:
+    def __init__(
+        self, 
+        dataset_name: str, 
+        names: List[str], 
+        tag: str, 
+        n_batches: Optional[int] = 1
+    ) -> None:
         self.dataset_name = dataset_name
         self.names = names
         self.tag = tag
         self.dataset = []
 
         for name in names:
-            data_samples = SampleCollection(
-                name=name,
-                tag=tag,
-            )
-            self.dataset.append(data_samples)
+            if n_batches > 1:
+                for batch in range(n_batches):
+                    data_samples = SampleCollection(
+                        name=f"{name}_batch_{batch}",
+                        tag=tag,
+                        n_batches=n_batches,
+                    )
+                    self.dataset.append(data_samples)
+            else:
+                data_samples = SampleCollection(
+                    name=name,
+                    tag=tag,
+                    n_batches=n_batches,
+                )
+                self.dataset.append(data_samples)
 
     def __getitem__(self, idx):
         return self.dataset[idx]

--- a/input_generator/utils.py
+++ b/input_generator/utils.py
@@ -212,7 +212,9 @@ def slice_coord_forces(
     cg_map: [n_cg_atoms, n_atomistic_atoms]
         Linear map characterizing the atomistic to CG configurational map with shape.
     mapping:
-        Mapping scheme to be used, must be either 'slice_aggregate' or 'slice_optimize'.
+        Mapping scheme to be used, 
+        Can be either a string, then must be either 'slice_aggregate' or 'slice_optimize',
+        Or can be directly a numpy array to use for projection
     force_stride:
         Striding to use for force projection results
     batch_size:
@@ -227,31 +229,38 @@ def slice_coord_forces(
     config_map_matrix = config_map.standard_matrix
     # taking only first 100 frames gives same results in ~1/15th of time
     constraints = guess_pairwise_constraints(coords[:100], threshold=5e-3)
-    if mapping == "slice_aggregate":
-        method = constraint_aware_uni_map
-        force_agg_results = project_forces(
-            coords=coords[::force_stride],
-            forces=forces[::force_stride],
-            coord_map=config_map,
-            constrained_inds=constraints,
-            method=method,
-        )
-    elif mapping == "slice_optimize":
-        method = qp_linear_map
-        l2 = 1e3
-        force_agg_results = project_forces(
-            coords=coords[::force_stride],
-            forces=forces[::force_stride],
-            coord_map=config_map,
-            constrained_inds=constraints,
-            method=method,
-            l2_regularization=l2,
-        )
+    if isinstance(mapping, str):
+        if mapping == "slice_aggregate":
+            method = constraint_aware_uni_map
+            force_agg_results = project_forces(
+                coords=coords[::force_stride],
+                forces=forces[::force_stride],
+                coord_map=config_map,
+                constrained_inds=constraints,
+                method=method,
+            )
+        elif mapping == "slice_optimize":
+            method = qp_linear_map
+            l2 = 1e3
+            force_agg_results = project_forces(
+                coords=coords[::force_stride],
+                forces=forces[::force_stride],
+                coord_map=config_map,
+                constrained_inds=constraints,
+                method=method,
+                l2_regularization=l2,
+            )
+        else:
+            raise RuntimeError(
+                f"Force mapping {mapping} is neither 'slice_aggregate' nor 'slice_optimize'."
+            )
+        force_map_matrix = force_agg_results["tmap"].force_map.standard_matrix
+    elif isinstance(mapping, np.ndarray):
+        force_map_matrix = mapping 
     else:
         raise RuntimeError(
-            f"Force mapping {mapping} is neither 'slice_aggregate' nor 'slice_optimize'."
+            f"Force mapping {mapping} is neither a string nor a numpy array."
         )
-    force_map_matrix = force_agg_results["tmap"].force_map.standard_matrix
 
     if batch_size != None: 
         cg_coords = batch_matmul(config_map_matrix, coords, batch_size=batch_size)

--- a/input_generator/utils.py
+++ b/input_generator/utils.py
@@ -154,6 +154,50 @@ def batch_matmul(map_matrix, X, batch_size):
     # Concatenate all chunks along the first axis (M dimension)
     return np.concatenate(results, axis=0)
 
+def chunker(array, n_batches):
+    """
+    Chunks an input array into a specified number of batches.
+
+    This function divides the input array into approximately equal-sized chunks.
+    The last chunk may contain more elements if the array length is not perfectly
+    divisible by the number of batches.
+
+    Parameters:
+    -----------
+    array : np.ndarray or List
+        The input array to be chunked.
+    n_batches : int 
+        The number of batches to divide the array into. Must be a positive
+        integer and less than or equal to the length of the array.
+
+    Returns:
+    --------
+    batched_array: List
+        A list of lists/arrays, where each inner list/array is a chunk of the original array.
+
+    Examples:
+    >>> chunker([1, 2, 3, 4, 5, 6, 7, 8, 9], 3)
+    [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+
+    >>> chunker([1, 2, 3, 4, 5], 2)
+    [[1, 2], [3, 4, 5]]
+
+    >>> chunker([1, 2, 3, 4, 5], 5)
+    [[1], [2], [3], [4], [5]]
+
+    >>> chunker([1, 2, 3, 4, 5], 1)
+    [[1, 2, 3, 4, 5]]
+    """
+    if n_batches == 1:
+        return [array]
+    assert n_batches <= len(array), "n_batches needs to be smaller than the array to chunk"
+    batched_array = []
+    n_elts_per_batch = len(array) // n_batches
+    for i in range(n_batches - 1):
+        batched_array.append(array[i*n_elts_per_batch:(i+1)*n_elts_per_batch])
+    # last batch might be larger, it contains the rest of the elements in the array
+    batched_array.append(array[(i+1)*n_elts_per_batch:])
+    return batched_array
 
 def slice_coord_forces(
     coords, forces, cg_map, mapping: str = "slice_aggregate", force_stride: int = 100, batch_size: Optional[int] = None

--- a/scripts/fit_priors.py
+++ b/scripts/fit_priors.py
@@ -43,7 +43,7 @@ def compute_statistics(
     save_figs: bool = True,
     save_sample_statistics: bool = False,
     weights_template_fn: Optional[str] = None,
-    traj_n_batches: Optional[int] = 1
+    mol_num_batches: Optional[int] = 1
 ):
     """
     Computes structural features and accumulates statistics on dataset samples
@@ -78,7 +78,7 @@ def compute_statistics(
         Whether to plot histograms of computed statistics
     weights_template_fn : str
         Template file location of weights to use for accumulating statistics
-    traj_n_batches : int
+    mol_num_batches : int
         If greater than 1, will save each molecule data into the specified number of batches 
         that will be treated as different samples
     """
@@ -90,7 +90,7 @@ def compute_statistics(
             all_nl_names.add(nl_name)
             nl_name2prior_builder[nl_name] = prior_builder
 
-    dataset = RawDataset(dataset_name, names, tag, n_batches=traj_n_batches)
+    dataset = RawDataset(dataset_name, names, tag, n_batches=mol_num_batches)
     for samples in tqdm(
         dataset, f"Compute histograms of CG data for {dataset_name} dataset..."
     ):

--- a/scripts/fit_priors.py
+++ b/scripts/fit_priors.py
@@ -43,6 +43,7 @@ def compute_statistics(
     save_figs: bool = True,
     save_sample_statistics: bool = False,
     weights_template_fn: Optional[str] = None,
+    traj_n_batches: Optional[int] = 1
 ):
     """
     Computes structural features and accumulates statistics on dataset samples
@@ -77,6 +78,9 @@ def compute_statistics(
         Whether to plot histograms of computed statistics
     weights_template_fn : str
         Template file location of weights to use for accumulating statistics
+    traj_n_batches : int
+        If greater than 1, will save each molecule data into the specified number of batches 
+        that will be treated as different samples
     """
 
     all_nl_names = set()
@@ -86,7 +90,7 @@ def compute_statistics(
             all_nl_names.add(nl_name)
             nl_name2prior_builder[nl_name] = prior_builder
 
-    dataset = RawDataset(dataset_name, names, tag)
+    dataset = RawDataset(dataset_name, names, tag, n_batches=traj_n_batches)
     for samples in tqdm(
         dataset, f"Compute histograms of CG data for {dataset_name} dataset..."
     ):

--- a/scripts/gen_input_data.py
+++ b/scripts/gen_input_data.py
@@ -134,6 +134,7 @@ def build_neighborlists(
     stride: int = 1,
     force_stride: int = 100,
     filter_cis: bool = False,
+    batch_size: Optional[int] = None,
     traj_n_batches: Optional[int] = 1
 ):
     """
@@ -173,6 +174,9 @@ def build_neighborlists(
         unused in this function
         present to allow the use of the same .yaml config for process_raw_dataset and build_neighborlists
     filter_cis : bool 
+        unused in this function
+        present to allow the use of the same .yaml config for process_raw_dataset and build_neighborlists
+    batch_size : bool 
         unused in this function
         present to allow the use of the same .yaml config for process_raw_dataset and build_neighborlists
     traj_n_batches : int

--- a/scripts/gen_input_data.py
+++ b/scripts/gen_input_data.py
@@ -99,11 +99,17 @@ def process_raw_dataset(
             raw_data_dir, samples.mol_name, stride=stride, batch=samples.batch, n_batches=samples.n_batches
         )
 
+        if samples.n_batches > 1 and samples.batch > 1:
+            # this ensures that we are using the same force map accross batches
+            mapping = samples.load_cg_force_map(save_dir)
+        else:
+            mapping = cg_mapping_strategy
+
         cg_coords, cg_forces = samples.process_coords_forces(
             aa_coords, 
             aa_forces,
             topology=samples.input_traj.top,
-            mapping=cg_mapping_strategy, 
+            mapping=mapping, 
             force_stride=force_stride,
             batch_size=batch_size,
             filter_cis=filter_cis

--- a/scripts/gen_input_data.py
+++ b/scripts/gen_input_data.py
@@ -36,7 +36,7 @@ def process_raw_dataset(
     force_stride: int = 100,
     filter_cis: Optional[bool] = False,
     batch_size: Optional[int] = None,
-    traj_n_batches: Optional[int] = 1
+    mol_num_batches: Optional[int] = 1
 ):
     """
     Applies coarse-grained mapping to coordinates and forces using input sample
@@ -78,11 +78,11 @@ def process_raw_dataset(
     batch_size : int
         Optional size in which performing batches of AA mapping to CG, to avoid
         memory overhead in large AA dataset
-    traj_n_batches : int
+    mol_num_batches : int
         If greater than 1, will save each molecule data into the specified number of batches 
         that will be treated as different samples
     """
-    dataset = RawDataset(dataset_name, names, tag, n_batches=traj_n_batches)
+    dataset = RawDataset(dataset_name, names, tag, n_batches=mol_num_batches)
     for samples in tqdm(dataset, f"Processing CG data for {dataset_name} dataset..."):
         samples.input_traj, samples.top_dataframe = sample_loader.get_traj_top(
             samples.mol_name, pdb_template_fn
@@ -141,7 +141,7 @@ def build_neighborlists(
     force_stride: int = 100,
     filter_cis: bool = False,
     batch_size: Optional[int] = None,
-    traj_n_batches: Optional[int] = 1
+    mol_num_batches: Optional[int] = 1
 ):
     """
     Generates neighbour lists for all samples in dataset using prior term information
@@ -185,7 +185,7 @@ def build_neighborlists(
     batch_size : bool 
         unused in this function
         present to allow the use of the same .yaml config for process_raw_dataset and build_neighborlists
-    traj_n_batches : int
+    mol_num_batches : int
         unused in this function
         present to allow the use of the same .yaml config for process_raw_dataset and build_neighborlists
     """

--- a/scripts/gen_input_data.py
+++ b/scripts/gen_input_data.py
@@ -35,7 +35,8 @@ def process_raw_dataset(
     stride: int = 1,
     force_stride: int = 100,
     filter_cis: Optional[bool] = False,
-    batch_size: Optional[int] = None
+    batch_size: Optional[int] = None,
+    traj_n_batches: Optional[int] = 1
 ):
     """
     Applies coarse-grained mapping to coordinates and forces using input sample
@@ -77,11 +78,14 @@ def process_raw_dataset(
     batch_size : int
         Optional size in which performing batches of AA mapping to CG, to avoid
         memory overhead in large AA dataset
+    traj_n_batches : int
+        If greater than 1, will save each molecule data into the specified number of batches 
+        that will be treated as different samples
     """
-    dataset = RawDataset(dataset_name, names, tag)
+    dataset = RawDataset(dataset_name, names, tag, n_batches=traj_n_batches)
     for samples in tqdm(dataset, f"Processing CG data for {dataset_name} dataset..."):
         samples.input_traj, samples.top_dataframe = sample_loader.get_traj_top(
-            samples.name, pdb_template_fn
+            samples.mol_name, pdb_template_fn
         )
 
         samples.apply_cg_mapping(
@@ -92,7 +96,7 @@ def process_raw_dataset(
         )
 
         aa_coords, aa_forces = sample_loader.load_coords_forces(
-            raw_data_dir, samples.name, stride=stride
+            raw_data_dir, samples.mol_name, stride=stride, batch=samples.batch, n_batches=samples.n_batches
         )
 
         cg_coords, cg_forces = samples.process_coords_forces(
@@ -128,7 +132,9 @@ def build_neighborlists(
     raw_data_dir: Union[str, None] = None,
     cg_mapping_strategy: Union[str, None] = None,
     stride: int = 1,
+    force_stride: int = 100,
     filter_cis: bool = False,
+    traj_n_batches: Optional[int] = 1
 ):
     """
     Generates neighbour lists for all samples in dataset using prior term information
@@ -159,6 +165,19 @@ def build_neighborlists(
         String identifying the specific combination of prior terms
     prior_builders : List[PriorBuilder]
         List of PriorBuilder objects and their corresponding parameters
+    
+    stride : int
+        unused in this function
+        present to allow the use of the same .yaml config for process_raw_dataset and build_neighborlists
+    force_stride : int
+        unused in this function
+        present to allow the use of the same .yaml config for process_raw_dataset and build_neighborlists
+    filter_cis : bool 
+        unused in this function
+        present to allow the use of the same .yaml config for process_raw_dataset and build_neighborlists
+    traj_n_batches : int
+        unused in this function
+        present to allow the use of the same .yaml config for process_raw_dataset and build_neighborlists
     """
     dataset = RawDataset(dataset_name, names, tag)
     for samples in tqdm(dataset, f"Building NL for {dataset_name} dataset..."):

--- a/scripts/merge_statistics.py
+++ b/scripts/merge_statistics.py
@@ -18,7 +18,8 @@ def merge_statistics(
     prior_tag: str,
     prior_builders: List[PriorBuilder],
     names: List[str],
-    tag: Optional[str] = None
+    tag: Optional[str] = None,
+    traj_n_batches: Optional[int] = 1
 ):
     """
     Merges statistics computed for separate datasets or for individual samples of the same dataset.
@@ -37,6 +38,8 @@ def merge_statistics(
         Optional label included to specify dataset for which sample statistics will be merged
     """
     all_stats = []
+    if traj_n_batches > 1:
+        names = [f"{n}_batch_{b}" for b in range(traj_n_batches) for n in names]
     for name in names:
         stats_fn = osp.join(save_dir, f"{get_output_tag([tag, name, prior_tag], placement='before')}prior_builders.pck")
         if osp.exists(stats_fn):

--- a/scripts/merge_statistics.py
+++ b/scripts/merge_statistics.py
@@ -19,7 +19,7 @@ def merge_statistics(
     prior_builders: List[PriorBuilder],
     names: List[str],
     tag: Optional[str] = None,
-    traj_n_batches: Optional[int] = 1
+    mol_num_batches: Optional[int] = 1
 ):
     """
     Merges statistics computed for separate datasets or for individual samples of the same dataset.
@@ -38,8 +38,8 @@ def merge_statistics(
         Optional label included to specify dataset for which sample statistics will be merged
     """
     all_stats = []
-    if traj_n_batches > 1:
-        names = [f"{n}_batch_{b}" for b in range(traj_n_batches) for n in names]
+    if mol_num_batches > 1:
+        names = [f"{n}_batch_{b}" for b in range(mol_num_batches) for n in names]
     for name in names:
         stats_fn = osp.join(save_dir, f"{get_output_tag([tag, name, prior_tag], placement='before')}prior_builders.pck")
         if osp.exists(stats_fn):

--- a/scripts/package_training_data.py
+++ b/scripts/package_training_data.py
@@ -34,7 +34,8 @@ def package_training_data(
     train_mols: Optional[List] = None,
     val_mols: Optional[List] = None,
     random_state: Optional[str] = None,
-    traj_n_batches: Optional[int] = 1
+    traj_n_batches: Optional[int] = 1,
+    keep_batches: Optional[bool] = False
 ):
     """
     Computes structural features and accumulates statistics on dataset samples
@@ -76,9 +77,15 @@ def package_training_data(
     traj_n_batches : int
         If greater than 1, will load each molecule data from the specified number of batches 
         that were be treated as different samples
+    keep_batches : bool
+        If set to True, batches will be put as individual molecules in the h5 dataset and 
+        the partition file will be built accordingly. Otherwise, if batches exist, they will be
+        accumulated into one single molecule.
     """
-
-    dataset = RawDataset(dataset_name, names, dataset_tag)
+    if keep_batches and traj_n_batches > 1:
+        dataset = RawDataset(dataset_name, names, dataset_tag, n_batches=traj_n_batches)
+    else:
+        dataset = RawDataset(dataset_name, names, dataset_tag)
     output_tag = get_output_tag([dataset_name, force_tag], placement="after")
 
     if save_h5:
@@ -91,7 +98,7 @@ def package_training_data(
                 dataset, f"Packaging {dataset_name} dataset..."
             ):
                 try:
-                    if traj_n_batches > 1:
+                    if traj_n_batches > 1 and not keep_batches:
                         cg_coords, cg_delta_forces, cg_embeds = samples.load_all_batches_training_inputs(
                             training_data_dir=training_data_dir,
                             force_tag=force_tag,
@@ -122,8 +129,12 @@ def package_training_data(
         # Create partition file
         fnout_part = osp.join(save_dir, f"partition{output_tag}.yaml")
         if single_protein:
-            train_mols = [f"{dataset_tag}{name}" for name in names]
-            val_mols = [f"{dataset_tag}{name}" for name in names]
+            if keep_batches and traj_n_batches > 1:
+                train_mols = [f"{dataset_tag}{name}_batch_{b}" for b in range(traj_n_batches) for name in names]
+                val_mols = [f"{dataset_tag}{name}_batch_{b}" for b in range(traj_n_batches) for name in names]
+            else:
+                train_mols = [f"{dataset_tag}{name}" for name in names]
+                val_mols = [f"{dataset_tag}{name}" for name in names]
             if train_size == None:
                 raise ValueError("For single-protein partitions, a train size has to be specified")
             if not isinstance(train_size, float):
@@ -164,13 +175,26 @@ def package_training_data(
         partition_opts["val"]["batch_sizes"] = {dataset_name: batch_size}
 
         if single_protein:
-            partition_opts["train"]["metasets"][dataset_name]["detailed_indices"] = {"filename": "./splits"}
+            partition_opts["train"]["metasets"][dataset_name]["detailed_indices"] = {}
+            partition_opts["val"]["metasets"][dataset_name]["detailed_indices"] = {}
             for mol in train_mols:
-                partition_opts["train"]["metasets"][dataset_name]["detailed_indices"][mol] = {
-                    "seed": random_state,
-                    "test_ratio": 0.0,
-                    "val_ratio": 1.0-train_size
-                }
+                with h5py.File(fnout_h5, "r") as f:
+                    n_frames = f[dataset_name][mol]["cg_coords"].shape[0]
+                train_frames, val_frames = train_test_split(
+                    np.arange(n_frames),
+                    train_size=train_size,
+                    shuffle=True,
+                    random_state=random_state
+                )
+                mol_output_tag = get_output_tag([mol, force_tag], placement="after")
+                train_fnout = osp.join(save_dir, f"train_idx{mol_output_tag}.npy")
+                val_fnout = osp.join(save_dir, f"val_idx{mol_output_tag}.npy")
+
+                np.save(train_fnout, train_frames)
+                np.save(val_fnout, val_frames)
+
+                partition_opts["train"]["metasets"][dataset_name]["detailed_indices"][mol] = train_fnout
+                partition_opts["val"]["metasets"][dataset_name]["detailed_indices"][mol] = val_fnout
         with open(fnout_part, "w") as ofile:
             yaml.dump(partition_opts, ofile)
 

--- a/scripts/package_training_data.py
+++ b/scripts/package_training_data.py
@@ -34,6 +34,7 @@ def package_training_data(
     train_mols: Optional[List] = None,
     val_mols: Optional[List] = None,
     random_state: Optional[str] = None,
+    traj_n_batches: Optional[int] = 1
 ):
     """
     Computes structural features and accumulates statistics on dataset samples
@@ -72,6 +73,9 @@ def package_training_data(
         Molecules to be used for validation set
     random_state : Optional[str]
         Controls shuffling applied to the data before applying the split
+    traj_n_batches : int
+        If greater than 1, will load each molecule data from the specified number of batches 
+        that were be treated as different samples
     """
 
     dataset = RawDataset(dataset_name, names, dataset_tag)
@@ -87,10 +91,17 @@ def package_training_data(
                 dataset, f"Packaging {dataset_name} dataset..."
             ):
                 try:
-                    cg_coords, cg_delta_forces, cg_embeds = samples.load_training_inputs(
-                        training_data_dir=training_data_dir,
-                        force_tag=force_tag,
-                    )
+                    if traj_n_batches > 1:
+                        cg_coords, cg_delta_forces, cg_embeds = samples.load_all_batches_training_inputs(
+                            training_data_dir=training_data_dir,
+                            force_tag=force_tag,
+                            traj_n_batches=traj_n_batches
+                        )
+                    else:
+                        cg_coords, cg_delta_forces, cg_embeds = samples.load_training_inputs(
+                            training_data_dir=training_data_dir,
+                            force_tag=force_tag,
+                        )
                 except FileNotFoundError:
                     print("Skipping molecule : ", samples.name)
                     continue

--- a/scripts/package_training_data.py
+++ b/scripts/package_training_data.py
@@ -34,7 +34,7 @@ def package_training_data(
     train_mols: Optional[List] = None,
     val_mols: Optional[List] = None,
     random_state: Optional[str] = None,
-    traj_n_batches: Optional[int] = 1,
+    mol_num_batches: Optional[int] = 1,
     keep_batches: Optional[bool] = False
 ):
     """
@@ -74,7 +74,7 @@ def package_training_data(
         Molecules to be used for validation set
     random_state : Optional[str]
         Controls shuffling applied to the data before applying the split
-    traj_n_batches : int
+    mol_num_batches : int
         If greater than 1, will load each molecule data from the specified number of batches 
         that were be treated as different samples
     keep_batches : bool
@@ -82,8 +82,8 @@ def package_training_data(
         the partition file will be built accordingly. Otherwise, if batches exist, they will be
         accumulated into one single molecule.
     """
-    if keep_batches and traj_n_batches > 1:
-        dataset = RawDataset(dataset_name, names, dataset_tag, n_batches=traj_n_batches)
+    if keep_batches and mol_num_batches > 1:
+        dataset = RawDataset(dataset_name, names, dataset_tag, n_batches=mol_num_batches)
     else:
         dataset = RawDataset(dataset_name, names, dataset_tag)
     output_tag = get_output_tag([dataset_name, force_tag], placement="after")
@@ -98,11 +98,11 @@ def package_training_data(
                 dataset, f"Packaging {dataset_name} dataset..."
             ):
                 try:
-                    if traj_n_batches > 1 and not keep_batches:
+                    if mol_num_batches > 1 and not keep_batches:
                         cg_coords, cg_delta_forces, cg_embeds = samples.load_all_batches_training_inputs(
                             training_data_dir=training_data_dir,
                             force_tag=force_tag,
-                            traj_n_batches=traj_n_batches
+                            mol_num_batches=mol_num_batches
                         )
                     else:
                         cg_coords, cg_delta_forces, cg_embeds = samples.load_training_inputs(
@@ -129,9 +129,9 @@ def package_training_data(
         # Create partition file
         fnout_part = osp.join(save_dir, f"partition{output_tag}.yaml")
         if single_protein:
-            if keep_batches and traj_n_batches > 1:
-                train_mols = [f"{dataset_tag}{name}_batch_{b}" for b in range(traj_n_batches) for name in names]
-                val_mols = [f"{dataset_tag}{name}_batch_{b}" for b in range(traj_n_batches) for name in names]
+            if keep_batches and mol_num_batches > 1:
+                train_mols = [f"{dataset_tag}{name}_batch_{b}" for b in range(mol_num_batches) for name in names]
+                val_mols = [f"{dataset_tag}{name}_batch_{b}" for b in range(mol_num_batches) for name in names]
             else:
                 train_mols = [f"{dataset_tag}{name}" for name in names]
                 val_mols = [f"{dataset_tag}{name}" for name in names]

--- a/scripts/produce_delta_forces.py
+++ b/scripts/produce_delta_forces.py
@@ -58,8 +58,8 @@ def produce_delta_forces(
     force_tag: str
         Optional tag to identify input for a particular run of delta force calculation
     traj_n_batches : int
-        If greater than 1, will save each molecule data into the specified number of batches 
-        that will be treated as different samples
+        If greater than 1, will load each molecule data from the specified number of batches 
+        that were be treated as different samples
     """
 
     prior_model = torch.load(open(prior_fn, "rb")).models.to(device)

--- a/scripts/produce_delta_forces.py
+++ b/scripts/produce_delta_forces.py
@@ -31,7 +31,7 @@ def produce_delta_forces(
     device: str,
     batch_size: int,
     force_tag: Optional[str] = None,
-    traj_n_batches: Optional[int] = 1
+    mol_num_batches: Optional[int] = 1
 ):
     """
     Removes prior energy terms from input forces to produce delta force input
@@ -57,13 +57,13 @@ def produce_delta_forces(
         Number of frames to take per batch
     force_tag: str
         Optional tag to identify input for a particular run of delta force calculation
-    traj_n_batches : int
+    mol_num_batches : int
         If greater than 1, will load each molecule data from the specified number of batches 
         that were be treated as different samples
     """
 
     prior_model = torch.load(open(prior_fn, "rb")).models.to(device)
-    dataset = RawDataset(dataset_name, names, tag, n_batches=traj_n_batches)
+    dataset = RawDataset(dataset_name, names, tag, n_batches=mol_num_batches)
     for samples in tqdm(
         dataset, f"Processing delta forces for {dataset_name} dataset..."
     ):

--- a/scripts/produce_delta_forces.py
+++ b/scripts/produce_delta_forces.py
@@ -31,7 +31,7 @@ def produce_delta_forces(
     device: str,
     batch_size: int,
     force_tag: Optional[str] = None,
-    traj_n_batches: Optional[str] = 1
+    traj_n_batches: Optional[int] = 1
 ):
     """
     Removes prior energy terms from input forces to produce delta force input

--- a/scripts/produce_delta_forces.py
+++ b/scripts/produce_delta_forces.py
@@ -31,6 +31,7 @@ def produce_delta_forces(
     device: str,
     batch_size: int,
     force_tag: Optional[str] = None,
+    traj_n_batches: Optional[str] = 1
 ):
     """
     Removes prior energy terms from input forces to produce delta force input
@@ -56,10 +57,13 @@ def produce_delta_forces(
         Number of frames to take per batch
     force_tag: str
         Optional tag to identify input for a particular run of delta force calculation
+    traj_n_batches : int
+        If greater than 1, will save each molecule data into the specified number of batches 
+        that will be treated as different samples
     """
 
     prior_model = torch.load(open(prior_fn, "rb")).models.to(device)
-    dataset = RawDataset(dataset_name, names, tag)
+    dataset = RawDataset(dataset_name, names, tag, n_batches=traj_n_batches)
     for samples in tqdm(
         dataset, f"Processing delta forces for {dataset_name} dataset..."
     ):


### PR DESCRIPTION
For big single-protein datasets, all-atom data might be too big to be loaded all at once in memory. For this we introduce a new argument in `process_raw_dataset` and in `compute_statistics` that is called `traj_n_batches`. Setting this to an integer bigger than 1 will separate your trajectories into `traj_n_batches` chunks that will be treated a separate samples with separate cg coordinates, forces and statistics. Statistics are then accumulated automatically at the end of `compute_statistics` such that the prior obtained is (almost) the same as if all trajectories had been loaded at once. 
A slight difference can appear between priors fitted on batched data and priors fitted on the full data because of the stride used in the statistics computation, that might introduce a shift in the frames used for fitting when batching. Setting this stride to 1 ensures the exact same prior, this was checked on the toy 1L2Y dataset.
Neighborlists are still common to one molecule, as are force-maps. Force-maps are computed once for the first batch and then reused in subsequent batches, to ensure consistency in the case of optimised force-maps.

This PR introduces the changes to allow the use of batching for trajectory loading and the corresponding documentation, as well as a few minor changes concerning the batched matrix multiplication introduced in PR#8, like adding the corresponding documentation to the examples README file and adding silent `batch_size` arguments to `build_neighborlists` to avoid failing when running with the same yaml as `process_raw_dataset`.

Note that the trajectory batching is for now only implemented in single-protein datasets. Indeed, transferable datasets never have enough data per molecule to blow up the memory, and as such the loaders have not been adapted to load trajectories in batches. This is due to the fact that the dimers only have one trajectory per molecule anyway so batching wouldn't have made any sense. Trying to load CATH, DIMER or OPEP molecules with trajectory batching will thus for now raise a NotImplementedError. Modifying this for CATH and OPEP is easy to do and can be done in the future if the need comes up, but for consistency I preferred to keep it the way it is for now.

Also note that this PR was branched from the filter-cis-proline branch that has not yet been merged. Please review PR#10 and merge it into this branch when ready before reviewing this.