### PR TITLE
Custom file erroe and black formatting

### DIFF
--- a/input_generator/embedding_maps.py
+++ b/input_generator/embedding_maps.py
@@ -52,6 +52,7 @@ class CGEmbeddingMapFiveBead(CGEmbeddingMap):
     def __init__(self):
         super().__init__(embedding_map_fivebead)
 
+
 class CGEmbeddingMapCA(CGEmbeddingMap):
     """
     One-bead embedding map defined by:
@@ -59,7 +60,7 @@ class CGEmbeddingMapCA(CGEmbeddingMap):
     """
 
     def __init__(self):
-        ca_dict = {key:emb for key,emb in embedding_map_fivebead.items() if emb <= 20}
+        ca_dict = {key: emb for key, emb in embedding_map_fivebead.items() if emb <= 20}
         super().__init__(ca_dict)
 
 
@@ -106,6 +107,7 @@ def embedding_fivebead(atom_df):
         print(f"Unknown atom name given: {name}")
         atom_type = "NA"
     return atom_type
+
 
 def embedding_ca(atom_df):
     """

--- a/input_generator/prior_fit/histogram.py
+++ b/input_generator/prior_fit/histogram.py
@@ -71,7 +71,13 @@ class HistogramsNL:
             Tensor of atom groups for which values have been computed
         """
         hists = compute_hist(
-            values, atom_types, mapping, self.n_bins, self.bmin, self.bmax, weights,
+            values,
+            atom_types,
+            mapping,
+            self.n_bins,
+            self.bmin,
+            self.bmax,
+            weights,
         )
         for k, hist in hists.items():
             self.data[nl_name][k] += hist
@@ -218,11 +224,13 @@ def compute_hist(
         val = values[mask]
         if len(val) == 0:
             continue
-        bins = torch.linspace(bmin, bmax, steps=nbins+1).type(val.dtype)
+        bins = torch.linspace(bmin, bmax, steps=nbins + 1).type(val.dtype)
 
         if isinstance(weights, torch.Tensor):
             n_atomgroups = int(val.shape[0] / weights.shape[0])
-            hist, _ = torch.histogram(val, bins=bins, weight=weights.tile((n_atomgroups,)))
+            hist, _ = torch.histogram(
+                val, bins=bins, weight=weights.tile((n_atomgroups,))
+            )
         else:
             hist, _ = torch.histogram(val, bins=bins)
         kk = tensor2tuple(unique_key)

--- a/input_generator/prior_gen.py
+++ b/input_generator/prior_gen.py
@@ -85,7 +85,9 @@ class PriorBuilder:
             weights = data.weights
         else:
             weights = None
-        self.histograms.accumulate_statistics(nl_name, values, atom_types, mapping, weights)
+        self.histograms.accumulate_statistics(
+            nl_name, values, atom_types, mapping, weights
+        )
 
 
 class Bonds(PriorBuilder):

--- a/input_generator/prior_nls.py
+++ b/input_generator/prior_nls.py
@@ -502,4 +502,3 @@ class CA_pseudo_dihedral:
 
     def get_fit_kwargs(self, nl_name):
         return {"n_degs": 5, "constrain_deg": 5}
-

--- a/scripts/add_decoys.py
+++ b/scripts/add_decoys.py
@@ -8,12 +8,13 @@ from jsonargparse import CLI
 from copy import deepcopy
 from time import ctime
 
-from mlcg.utils import load_yaml, dump_yaml 
+from mlcg.utils import load_yaml, dump_yaml
 
 rng: Final = r.default_rng()
 
 META_CG_EMBEDS_KEY: Final = "cg_embeds"
 META_CG_NFRAMES_KEY: Final = "N_frames"
+
 
 def longest_common_substring(s1, s2):
     # Create a 2D array to store lengths of longest common suffixes
@@ -21,7 +22,7 @@ def longest_common_substring(s1, s2):
     dp = [[0] * (n + 1) for _ in range(m + 1)]
     longest_len = 0
     end_pos = 0  # To store the end position of the longest common substring in s1
-    
+
     # Build the dp table
     for i in range(1, m + 1):
         for j in range(1, n + 1):
@@ -32,21 +33,23 @@ def longest_common_substring(s1, s2):
                     end_pos = i
             else:
                 dp[i][j] = 0
-    
+
     # Extract the longest common substring
-    return s1[end_pos - longest_len:end_pos]
+    return s1[end_pos - longest_len : end_pos]
+
 
 def longest_common_substring_multiple(strings):
     # Start by assuming the entire first string as a candidate
     common_substring = strings[0]
-    
+
     # Find the longest common substring for each subsequent string
     for s in strings[1:]:
         common_substring = longest_common_substring(common_substring, s)
         if not common_substring:
             break  # No common substring found, exit early
-    
+
     return common_substring
+
 
 def add_noise_decoy_molecule(
     source_molecule: h5py.Group,
@@ -123,6 +126,7 @@ def add_noise_decoy_molecule(
 
     return new_molecule_group
 
+
 def add_decoy(
     h5_files: List[str],
     datasets: List[str],
@@ -134,87 +138,91 @@ def add_decoy(
     """
     Adds decoy molecules with Gaussian noise to the specified HDF5 datasets, optionally combines them into a single HDF5 file.
 
-    This function processes multiple HDF5 files, and for each file, it generates decoy molecules by adding Gaussian noise to 
-    the coordinates of the molecules in the specified dataset. The decoys are stored as separate molecules in the same datasets, with the option 
-    to append them to the existing h5s or to copy the existing h5s into new ones before appending the decoy molecules. 
+    This function processes multiple HDF5 files, and for each file, it generates decoy molecules by adding Gaussian noise to
+    the coordinates of the molecules in the specified dataset. The decoys are stored as separate molecules in the same datasets, with the option
+    to append them to the existing h5s or to copy the existing h5s into new ones before appending the decoy molecules.
     The decoy molecules are given a name based on the provided prefix.
 
-    After decoys are added to all specified files, the function can optionally combine the provided h5 files 
-    into a single combined HDF5 file, using external links to the original files. The name of the combined file can either 
+    After decoys are added to all specified files, the function can optionally combine the provided h5 files
+    into a single combined HDF5 file, using external links to the original files. The name of the combined file can either
     be provided or generated automatically based on the input files.
 
     Arguments:
     ----------
     h5_files: List[str]
-        A list of paths to the HDF5 files where decoy molecules should be added. Each file should contain one single dataset specified 
+        A list of paths to the HDF5 files where decoy molecules should be added. Each file should contain one single dataset specified
         in the `datasets` argument.
 
     datasets: List[str]
-        A list of dataset names within each corresponding HDF5 file. These datasets should contain molecules where 
+        A list of dataset names within each corresponding HDF5 file. These datasets should contain molecules where
         decoys will be added.
-    
+
     mol_name_prefix: str
-        The prefix to be added to the name of each decoy molecule. Each decoy molecule will be named by appending its 
+        The prefix to be added to the name of each decoy molecule. Each decoy molecule will be named by appending its
         original molecule name to this prefix.
 
     scale: float
         The standard deviation of the Gaussian noise to be added to the coordinates of the beads.
 
     stride: Optional[int], default=50
-        The stride value to be used when selecting frames from the original molecules. For example, a stride of 50 will 
+        The stride value to be used when selecting frames from the original molecules. For example, a stride of 50 will
         select every 50th frame from the original molecule dataset. If not specified, defaults to 50.
 
     append: Optional[bool], default=True
-        If `True`, decoy molecules will be added to the datasets in the existing HDF5 files. If `False`, the HDF5 file 
+        If `True`, decoy molecules will be added to the datasets in the existing HDF5 files. If `False`, the HDF5 file
         will be copied before appending the decoy molecules in the new HDF5 file.
 
     Notes:
     -----
     - The `scale` value controls the level of noise added to the decoy molecules. A larger value will result in more distorted configurations.
-    - The `stride` argument helps reduce the number of frames included in the decoy molecule by selecting a subset based on 
+    - The `stride` argument helps reduce the number of frames included in the decoy molecule by selecting a subset based on
       the specified interval. The higher the stride the less decoys are present in the dataset.
     """
-    assert len(h5_files) == len(datasets), "this function currently cannot handle more than one dataset per h5 file"
+    assert len(h5_files) == len(
+        datasets
+    ), "this function currently cannot handle more than one dataset per h5 file"
     decoy_h5_files = []
     for i, h5_file in enumerate(h5_files):
-        if not append: # copy h5 datasets 
-            os.system(f"cp {os.path.dirname(h5_file)} {os.path.join(os.path.dirname(h5_file), f'DECOY_{os.path.basename(h5_dataset)}')}")
-            decoy_h5_file = os.path.join(os.path.dirname(h5_file), f'DECOY_{os.path.basename(h5_file)}')
+        if not append:  # copy h5 datasets
+            os.system(
+                f"cp {os.path.dirname(h5_file)} {os.path.join(os.path.dirname(h5_file), f'DECOY_{os.path.basename(h5_dataset)}')}"
+            )
+            decoy_h5_file = os.path.join(
+                os.path.dirname(h5_file), f"DECOY_{os.path.basename(h5_file)}"
+            )
         else:
             decoy_h5_file = h5_file
         decoy_h5_files.append(decoy_h5_file)
 
         with h5py.File(decoy_h5_file, "a") as f:
-
             for mol in tqdm(f[datasets[i]].keys(), desc=f"Adding {datasets[i]} decoys"):
                 add_noise_decoy_molecule(
-                    source_molecule=f[datasets[i]][mol], 
+                    source_molecule=f[datasets[i]][mol],
                     location=f[datasets[i]],
                     scale=5.0,
-                    name=f"{mol_name_prefix}_{mol}"
+                    name=f"{mol_name_prefix}_{mol}",
                 )
 
+
 def update_partition_file(
-    partition_file: str,
-    mol_name_prefixes: List[str],
-    partition_name: str
+    partition_file: str, mol_name_prefixes: List[str], partition_name: str
 ) -> None:
     """
     Updates a partition file by adding new molecules with specified prefixes to the "molecules" list of existing datasets.
 
-    This function loads a YAML partition file, updates it by appending molecule names with specified prefixes, and then 
-    saves the updated partition back to a new YAML file. It is typically used in scenarios where new decoy molecules, 
+    This function loads a YAML partition file, updates it by appending molecule names with specified prefixes, and then
+    saves the updated partition back to a new YAML file. It is typically used in scenarios where new decoy molecules,
     generated with a prefix (such as a decoy identifier), need to be added to the partition file.
 
     Arguments:
     ----------
     partition_file: str
-        Path to the original partition YAML file that contains metadata about the datasets and molecules. The function will 
+        Path to the original partition YAML file that contains metadata about the datasets and molecules. The function will
         read this file and modify the "molecules" list within the "metasets" section of the partition.
 
     mol_name_prefixes: List[str]
-        A list of prefixes to be added to the names of existing molecules in the partition file. Each prefix will be prepended 
-        to the names of the molecules in the partition's "molecules" list, essentially creating new "decoy" molecules with 
+        A list of prefixes to be added to the names of existing molecules in the partition file. Each prefix will be prepended
+        to the names of the molecules in the partition's "molecules" list, essentially creating new "decoy" molecules with
         the prefixed names.
 
     partition_name: str
@@ -222,7 +230,7 @@ def update_partition_file(
 
     Notes:
     -----
-    - The function assumes that the partition YAML file follows a specific structure, where molecule names are listed under 
+    - The function assumes that the partition YAML file follows a specific structure, where molecule names are listed under
       the "train" section in the "metasets" -> "molecules" key.
     - The function does not add decoy molecules to the validation dataset provided in the partition file
 
@@ -258,8 +266,11 @@ def update_partition_file(
         mols = deepcopy(partition["train"]["metasets"][dataset]["molecules"])
         for mol in mols:
             for prefix in mol_name_prefixes:
-                partition["train"]["metasets"][dataset]["molecules"].append(f"{prefix}_{mol}")
+                partition["train"]["metasets"][dataset]["molecules"].append(
+                    f"{prefix}_{mol}"
+                )
     dump_yaml(partition_name, partition)
+
 
 if __name__ == "__main__":
     print("Start add_decoys.py: {}".format(ctime()))

--- a/scripts/fit_priors.py
+++ b/scripts/fit_priors.py
@@ -91,13 +91,19 @@ def compute_statistics(
         dataset, f"Compute histograms of CG data for {dataset_name} dataset..."
     ):
         if weights_template_fn != None and not osp.exists(
-                osp.join(save_dir, weights_template_fn.format(samples.name))
-                ):
-            warnings.warn(f"Could not find weights for sample {samples.name}; the file {osp.join(save_dir, weights_template_fn.format(samples.name))} does not exist. This entry will be skipped.")
+            osp.join(save_dir, weights_template_fn.format(samples.name))
+        ):
+            warnings.warn(
+                f"Could not find weights for sample {samples.name}; the file {osp.join(save_dir, weights_template_fn.format(samples.name))} does not exist. This entry will be skipped."
+            )
             continue
 
         batch_list = samples.load_cg_output_into_batches(
-            save_dir, prior_tag, batch_size, stride, weights_template_fn=weights_template_fn,
+            save_dir,
+            prior_tag,
+            batch_size,
+            stride,
+            weights_template_fn=weights_template_fn,
         )
         nl_names = set(batch_list[0].neighbor_list.keys())
 
@@ -106,29 +112,37 @@ def compute_statistics(
         ), f"some of the NL names '{nl_names}' in {dataset_name}:{samples.name} have not been registered in the nl_builder '{all_nl_names}'"
 
         if save_sample_statistics:
-            sample_fnout = osp.join(save_dir, f"{get_output_tag([samples.tag, samples.name, prior_tag, statistics_tag], placement='before')}prior_builders.pck")
+            sample_fnout = osp.join(
+                save_dir,
+                f"{get_output_tag([samples.tag, samples.name, prior_tag, statistics_tag], placement='before')}prior_builders.pck",
+            )
             sample_prior_builders = [
                 deepcopy(prior_builder) for prior_builder in prior_builders
             ]
 
             sample_nl_name2prior_builder = {}
-            for prior_builder in sample_prior_builders: 
+            for prior_builder in sample_prior_builders:
                 for nl_name in prior_builder.nl_builder.nl_names:
-                    if nl_name in prior_builder.histograms.data.keys() and nl_name not in nl_names: 
+                    if (
+                        nl_name in prior_builder.histograms.data.keys()
+                        and nl_name not in nl_names
+                    ):
                         prior_builder.histograms.data.pop(nl_name)
                     prior_builder.histograms.data[nl_name].clear()
                     sample_nl_name2prior_builder[nl_name] = prior_builder
 
-            for batch in tqdm(batch_list, f"molecule name: {samples.name}", leave=False):
+            for batch in tqdm(
+                batch_list, f"molecule name: {samples.name}", leave=False
+            ):
                 batch = batch.to(device)
                 for nl_name in nl_names:
                     prior_builder = sample_nl_name2prior_builder[nl_name]
                     prior_builder.accumulate_statistics(nl_name, batch)
-            
+
             with open(sample_fnout, "wb") as f:
                 pck.dump(sample_prior_builders, f)
-            
-            continue # does not save accumulated statistics if sample statistics saved
+
+            continue  # does not save accumulated statistics if sample statistics saved
 
         for batch in tqdm(batch_list, f"molecule name: {samples.name}", leave=False):
             batch = batch.to(device)
@@ -147,10 +161,13 @@ def compute_statistics(
                     dpi=300,
                     bbox_inches="tight",
                 )
-    
+
     if not save_sample_statistics:
         # cummulative statistics are only saved if individual statistics were not saved
-        fnout = osp.join(save_dir, f"{get_output_tag([samples.tag, prior_tag], placement='before')}prior_builders.pck")
+        fnout = osp.join(
+            save_dir,
+            f"{get_output_tag([samples.tag, prior_tag], placement='before')}prior_builders.pck",
+        )
         with open(fnout, "wb") as f:
             pck.dump(prior_builders, f)
 

--- a/scripts/gen_input_data.py
+++ b/scripts/gen_input_data.py
@@ -34,7 +34,7 @@ def process_raw_dataset(
     cg_mapping_strategy: str,
     stride: int = 1,
     force_stride: int = 100,
-    batch_size: Optional[int] = None
+    batch_size: Optional[int] = None,
 ):
     """
     Applies coarse-grained mapping to coordinates and forces using input sample
@@ -91,14 +91,17 @@ def process_raw_dataset(
         )
 
         cg_coords, cg_forces = samples.process_coords_forces(
-            aa_coords, aa_forces, mapping=cg_mapping_strategy, force_stride=force_stride, batch_size=batch_size
+            aa_coords,
+            aa_forces,
+            mapping=cg_mapping_strategy,
+            force_stride=force_stride,
+            batch_size=batch_size,
         )
 
         samples.save_cg_output(save_dir, save_coord_force=True, save_cg_maps=True)
-        # the sample object will retain the output so it makes sense to delete them 
+        # the sample object will retain the output so it makes sense to delete them
         del samples.cg_coords
         del samples.cg_forces
-        
 
 
 def build_neighborlists(

--- a/scripts/gen_sim_input.py
+++ b/scripts/gen_sim_input.py
@@ -125,7 +125,10 @@ def process_sim_input(
         data.neighbor_list = deepcopy(nls)
         data_list.append(data)
 
-    torch.save(data_list, f"{save_dir}{get_output_tag([dataset_name, tag], placement='before')}configurations.pt")
+    torch.save(
+        data_list,
+        f"{save_dir}{get_output_tag([dataset_name, tag], placement='before')}configurations.pt",
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/merge_statistics.py
+++ b/scripts/merge_statistics.py
@@ -12,12 +12,13 @@ from input_generator.utils import get_output_tag
 from jsonargparse import CLI
 from typing import List, Optional
 
+
 def merge_statistics(
     save_dir: str,
     prior_tag: str,
     prior_builders: List[PriorBuilder],
     names: List[str],
-    tag: Optional[str] = None
+    tag: Optional[str] = None,
 ):
     """
     Merges statistics computed for separate datasets or for individual samples of the same dataset.
@@ -37,12 +38,18 @@ def merge_statistics(
     """
     all_stats = []
     for name in names:
-        stats_fn = osp.join(save_dir, f"{get_output_tag([tag, name, prior_tag], placement='before')}prior_builders.pck")
+        stats_fn = osp.join(
+            save_dir,
+            f"{get_output_tag([tag, name, prior_tag], placement='before')}prior_builders.pck",
+        )
         with open(stats_fn, "rb") as ifile:
             stats = pkl.load(ifile)
         all_stats.append(stats)
-    
-    fnout =  osp.join(save_dir, f"{get_output_tag([tag, prior_tag], placement='before')}prior_builders.pck")
+
+    fnout = osp.join(
+        save_dir,
+        f"{get_output_tag([tag, prior_tag], placement='before')}prior_builders.pck",
+    )
     builder_dict = {}
     for prior_builder in prior_builders:
         builder_dict[prior_builder.name] = prior_builder
@@ -56,7 +63,7 @@ def merge_statistics(
                 hists = builder.histograms[nl_name]
                 for k, hist in hists.items():
                     combined_builder.histograms.data[nl_name][k] += hist
-    
+
     with open(fnout, "wb") as ofile:
         pkl.dump(prior_builders, ofile)
 

--- a/scripts/produce_delta_forces.py
+++ b/scripts/produce_delta_forces.py
@@ -21,6 +21,7 @@ from time import ctime
 from typing import Dict, List, Union, Callable, Optional
 from jsonargparse import CLI
 
+
 def produce_delta_forces(
     dataset_name: str,
     names: List[str],
@@ -93,10 +94,14 @@ def produce_delta_forces(
                 if j < len(sub_data_list):
                     delta_force = sub_data_list[j].forces.detach().cpu()
                     delta_forces.append(delta_force.numpy())
-        
-        fnout = os.path.join(save_dir, f"{get_output_tag([tag, samples.name, prior_tag, force_tag], placement='before')}delta_forces.npy")
+
+        fnout = os.path.join(
+            save_dir,
+            f"{get_output_tag([tag, samples.name, prior_tag, force_tag], placement='before')}delta_forces.npy",
+        )
         np.save(
-            fnout, np.concatenate(delta_forces, axis=0).reshape(*coords.shape),
+            fnout,
+            np.concatenate(delta_forces, axis=0).reshape(*coords.shape),
         )
 
 


### PR DESCRIPTION
Currently the script for packaging has a try ... except block to skip molecules that have missing files. Due to this, the packaging can silently fail in some cases, like when the name of the prior or of the dataset is misspelled.

I made a custom error class so that when this happens we know which file is missing for the molecule and this becomes easier to debug.

Beside this, I've also formatted with black some of the files in `./input_generator` and `./scripts`.