### PR TITLE
Add support for polynomial prior

### DIFF
--- a/examples/configuration_files/carbon_alpha_configs/ca_trpcage_priors.yaml
+++ b/examples/configuration_files/carbon_alpha_configs/ca_trpcage_priors.yaml
@@ -14,7 +14,8 @@ prior_builders:
       name: angles
       separate_termini: false
       nl_builder: input_generator.StandardAngles
-      prior_fit_fn: input_generator.fit_harmonic_from_potential_estimates
+      prior_fit_fn: input_generator.prior_fit.fit_polynomial_from_potential_estimates
+      prior_cls: mlcg.nn.prior.QuarticAngles
       n_bins: 100
       bmin: -1.1
       bmax: 1.1

--- a/input_generator/prior_fit/__init__.py
+++ b/input_generator/prior_fit/__init__.py
@@ -5,4 +5,5 @@ from .repulsion import (
     repulsion,
 )
 from .dihedral import fit_dihedral_from_potential_estimates, dihedral
+from .polynomial import fit_polynomial_from_potential_estimates, polynomial_wrapper_fit_func
 from .histogram import HistogramsNL

--- a/input_generator/prior_fit/dihedral.py
+++ b/input_generator/prior_fit/dihedral.py
@@ -3,7 +3,7 @@ from typing import Dict, Optional
 from scipy.integrate import trapezoid
 from scipy.optimize import curve_fit
 import numpy as np
-
+from .utils import neg_log_likelihood
 
 def dihedral(
     theta: torch.Tensor,
@@ -54,14 +54,6 @@ def dihedral_wrapper_fit_func(theta: torch.Tensor, *args) -> torch.Tensor:
     k2s = torch.tensor(k2s).view(-1, num_ks)
     return dihedral(theta, v_0, k1s, k2s)
 
-
-def neg_log_likelihood(y, yhat):
-    """
-    Convert dG to probability and use KL divergence to get difference between
-    predicted and actual
-    """
-    L = torch.sum(torch.exp(-y) * torch.log(torch.exp(-yhat)))
-    return -L
 
 
 def _init_parameters(n_degs):

--- a/input_generator/prior_fit/polynomial.py
+++ b/input_generator/prior_fit/polynomial.py
@@ -1,0 +1,205 @@
+import numpy as np
+import warnings
+from scipy.integrate import trapezoid
+from scipy.optimize import curve_fit
+import torch
+from typing import Optional
+
+from .utils import compute_aic
+
+
+def polynomial(x: torch.Tensor, ks: torch.Tensor, V0 : torch.Tensor):
+    """Harmonic interaction in the form of a series. The shape of the tensors
+        should match between each other.
+
+    .. math:
+
+        V(r) = V0 + \sum_{n=1}^{deg} k_n x^n
+
+    """
+    V = ks[0]*x
+    for p, k in enumerate(ks[1:],start=2):
+        V += k * torch.pow(x, p)
+    V += V0
+    return V
+
+def polynomial_wrapper_fit_func(x, *args):
+    args = args[0]
+    V0 = torch.tensor(args[0])
+    ks = torch.tensor(args[1:])
+    return polynomial(x, ks, V0)
+
+def _init_parameters(n_degs, bin_centers_nz=None, dG_nz=None):
+    ks = [1.0 for _ in range(n_degs)]
+    V0 = -1.0
+    p0 = [V0]
+    p0.extend(ks)
+    return p0
+
+def _init_parameter_dict(n_degs):
+    """Helper method for initializing the parameter dictionary"""
+    stat = {
+        "ks": {},
+        "v_0" : 0.0
+    }
+    k_names = ["k_" + str(ii) for ii in range(1,n_degs+1)]
+    for ii in range(n_degs):
+        k_name = k_names[ii]
+        stat["ks"][k_name] = {}
+    return stat
+
+def _make_parameter_dict(stat, popt, n_degs):
+    """Helper method for constructing a fitted parameter dictionary"""
+    stat["v_0"] = popt[0]
+    k_names = sorted(list(stat["ks"].keys()))
+    for ii in range(n_degs):
+        k_name = k_names[ii]
+        stat["ks"][k_name] = popt[ii+1]
+
+        
+    return stat
+
+def _linear_regression(xs : torch.Tensor, ys : torch.Tensor, n_degs : int):
+    """Vanilla linear regression"""
+    features = [torch.ones_like(xs)]
+    for n in range(n_degs):
+        features.append(torch.pow(xs,n + 1))
+    features = torch.stack(features).t()
+    ys = ys.to(features.dtype)
+    sol = torch.linalg.lstsq(features, ys.t())
+    return sol
+
+def _numpy_fit(xs : torch.Tensor, ys : torch.Tensor, n_degs : int):
+    """Regression through numpy"""
+    sol = np.polynomial.Polynomial.fit(xs.numpy(),ys.numpy(),deg=n_degs)
+    return sol
+
+def _scipy_fit(xs : torch.Tensor, ys : torch.Tensor, n_degs : int, bounds: Optional = None):
+    """Regression through scipy
+    
+        The `bounds` argument is passed to `scipy.optimize.curve_fit` to ensure bounds in the polynomial
+    """
+    if bounds is None:
+        bounds = (-np.inf,np.inf) 
+    p0 = _init_parameters(
+                    n_degs, xs, ys
+                )
+    p0[-2]=0
+    popt, _ = curve_fit(
+        lambda theta, *p0: polynomial_wrapper_fit_func(
+            theta, p0
+        ),
+        xs,
+        ys,
+        p0=p0,
+        bounds = bounds,
+        ftol=1e-5,
+    )
+    return popt
+
+def _polynomial_fit(xs:torch.Tensor,ys:torch.Tensor,n_degs:int,regression_method:str="scipy"):
+    _valid_regression_methods = ["linear","numpy","scipy"]
+    popt = []
+    if regression_method == "linear":
+        sol = _linear_regression(xs, ys, n_degs)
+        popt = sol.solution.numpy().tolist()
+    elif regression_method == "numpy":
+        sol = _numpy_fit(xs, ys, n_degs)
+        popt = list(sol.convert().coef)
+    elif regression_method == "scipy":
+        low_bounds =  [-np.inf for _ in range(n_degs+1)]
+        # enforce that the coefficient of the leading degree is positive
+        low_bounds[-1] = 0
+        high_bounds = [np.inf for _ in range(n_degs+1)]
+        popt = _scipy_fit(xs, ys, n_degs, bounds = (low_bounds,high_bounds))
+        dev = [idx*popt[idx] for idx in range(1,n_degs+1)]
+        dev_val_at_min_1 = polynomial_wrapper_fit_func(torch.tensor(-1),dev)
+        dev_val_at_plus_1 = polynomial_wrapper_fit_func(torch.tensor(1),dev)
+        if dev_val_at_min_1*dev_val_at_plus_1 > 0:
+            # relaunch the fit making sure that the second largest degree has no coefficient
+            low_bounds[-2] = -1e-2
+            high_bounds[-2] = 1e-2
+            popt = _scipy_fit(xs, ys, n_degs, bounds = (low_bounds,high_bounds))
+    else:
+        raise ValueError(
+            f"regression method {regression_method} is not in {_valid_regression_methods} "
+        )
+    if popt[-1] <= 0:
+        print()
+    return popt
+
+
+def fit_polynomial_from_potential_estimates(
+    bin_centers_nz: torch.Tensor,
+    dG_nz: torch.Tensor,
+    n_degs: int = 4,
+    constrain_deg: Optional[int] = 4,
+    regression_method: str = "scipy",
+    **kwargs
+):
+    """
+    Loop over n_degs basins and use either the AIC criterion
+    or a prechosen degree to select best fit. Parameter fitting
+    occurs over unmaksed regions of the free energy only.
+
+    Parameters
+    ----------
+    bin_centers_nz:
+        Bin centers over which the fit is carried out
+    dG_nz:
+        The emperical free energy correspinding to the bin centers
+    n_degs:
+        The maximum number of degrees to attempt to fit if using the AIC
+        criterion for prior model selection
+    constrain_deg:
+        If not None, a single fit is produced for the specified integer
+        degree instead of using the AIC criterion for fit selection between
+        multiple degrees
+
+    Returns
+    -------
+        Statistics dictionary with fitted interaction parameters
+    """
+
+    integral = torch.tensor(
+        float(trapezoid(dG_nz.cpu().numpy(), bin_centers_nz.cpu().numpy()))
+    )
+    mask = torch.abs(dG_nz) > 1e-4 * torch.abs(integral)
+    if constrain_deg is not None:
+        stat = _init_parameter_dict(n_degs)
+        popt = _polynomial_fit(bin_centers_nz[mask], dG_nz[mask], n_degs,regression_method)
+        stat = _make_parameter_dict(stat, popt, n_degs)
+    else:
+        try:
+            # Determine best fit for unknown # of parameters
+            stat = _init_parameter_dict(n_degs)
+            popts = []
+            aics = []
+            degs = range(2, n_degs + 1,2)
+            for deg in degs:
+                popt = _polynomial_fit(bin_centers_nz[mask], dG_nz[mask], n_degs,regression_method)
+                fitted_dG = polynomial_wrapper_fit_func(bin_centers_nz[mask],popt)
+                free_parameters = deg + 1
+                aic = compute_aic(
+                    fitted_dG, dG_nz[mask], free_parameters
+                )
+                popts.append(popt)
+                aics.append(aic)
+            # Select only priors that have upward curve at both regions of unexplored
+            # phase space. i.e. (powers of 2)
+            min_aic = min(aics)
+            min_i_aic = aics.index(min_aic)
+            popt = popts[min_i_aic]
+            stat = _make_parameter_dict(stat, popt, n_degs)
+        except RuntimeError:
+            print("failed to fit potential estimate for Polynomial")
+            stat = _init_parameter_dict(n_degs)
+            k_names = sorted(list(stat["ks"].keys()))
+            x_0_names = sorted(list(stat["x_0s"].keys()))
+            for ii in range(n_degs):
+                k1_name = k_names[ii]
+                k2_name = x_0_names[ii]
+                stat["ks"][k1_name] = torch.tensor(float("nan"))
+                stat["x_0s"][k2_name] = torch.tensor(float("nan"))
+    return stat
+

--- a/input_generator/prior_fit/utils.py
+++ b/input_generator/prior_fit/utils.py
@@ -1,0 +1,23 @@
+import torch
+
+def neg_log_likelihood(y, yhat):
+    """
+    Convert dG to probability and use KL divergence to get difference between
+    predicted and actual
+    """
+    L = torch.sum(torch.exp(-y) * torch.log(torch.exp(-yhat)))
+    return -L
+
+
+
+def compute_aic(real_distibution, ref_distribution, free_parameters):
+    """Method for computing the AIC"""
+    aic = (
+        2
+        * neg_log_likelihood(
+            ref_distribution,
+            real_distibution,
+        )
+        + 2 * free_parameters
+    )
+    return aic

--- a/input_generator/prior_gen.py
+++ b/input_generator/prior_gen.py
@@ -201,6 +201,9 @@ class Angles(PriorBuilder):
         Upper bound of bin edges
     prior_fit_fn:
         Function to be used in fitting potential from statistics
+    prior_cls:
+        Prior class to be used. It must be able to be initialized from the output
+        of the `prior_fit_fn`
     """
 
     def __init__(
@@ -212,6 +215,7 @@ class Angles(PriorBuilder):
         bmin: float,
         bmax: float,
         prior_fit_fn: Callable,
+        prior_cls=GeneralAngles,
     ) -> None:
         super().__init__(
             histograms=HistogramsNL(
@@ -221,7 +225,7 @@ class Angles(PriorBuilder):
             ),
             nl_builder=nl_builder,
             prior_fit_fn=prior_fit_fn,
-            prior_cls=GeneralAngles,
+            prior_cls=prior_cls,
         )
         self.name = name
         self.type = "angles"


### PR DESCRIPTION
This pull request adds support for using MLCG tk with a `QuarticAngles` prior that uses a degree-4 polynomial to fit angles. 

This PR is coupled to [another PR in mlcg](https://github.com/ClementiGroup/mlcg/pull/8) implementing such prior.

The `examples/configuration_files/carbon_alpha_configs/ca_trpcage_priors.yaml` has been modified to use the new quartic prior. It can be tested with this.