### PR TITLE
fixed bug on masses assignation

### DIFF
--- a/scripts/gen_sim_input.py
+++ b/scripts/gen_sim_input.py
@@ -94,7 +94,7 @@ def process_sim_input(
 
         cg_trajs = samples.input_traj.atom_slice(samples.cg_atom_indices)
         cg_masses = (
-            np.array([round(atom.element.mass) for atom in cg_trajs[0].topology.atoms])
+            np.array([atom.element.mass for atom in cg_trajs[0].topology.atoms])
             / mass_scale
         )
         prior_nls = samples.get_prior_nls(

--- a/scripts/gen_sim_input.py
+++ b/scripts/gen_sim_input.py
@@ -94,7 +94,7 @@ def process_sim_input(
 
         cg_trajs = samples.input_traj.atom_slice(samples.cg_atom_indices)
         cg_masses = (
-            np.array([int(atom.element.mass) for atom in cg_trajs[0].topology.atoms])
+            np.array([round(atom.element.mass) for atom in cg_trajs[0].topology.atoms])
             / mass_scale
         )
         prior_nls = samples.get_prior_nls(


### PR DESCRIPTION
I was checking masses assignation of the starting structure and for 5 beads resolution for Oxygens they were different from what I expected after the default rescaling of 418.4 (rescaled 0.0359 vs expected 0.0382). If rescaling is not applied they can be seen being set to 15 instead of 16. This was just a mere int/rounding problem (mass of oxygen 15.99)
I put the round in order to keep the same idea but we can also come up with a different solution