### PR TITLE
Use sparse arrays for CG mappings

### DIFF
--- a/input_generator/raw_dataset.py
+++ b/input_generator/raw_dataset.py
@@ -8,7 +8,6 @@ import mdtraj as md
 import torch
 import warnings
 import os
-from importlib import import_module
 
 from torch_geometric.data.collate import collate
 
@@ -341,9 +340,11 @@ class SampleCollection:
                     if force_stride == 1:
                         break
 
-                cg_coords, cg_forces, force_map = slice_coord_forces(
+                cg_coords, cg_forces, cg_map, force_map = slice_coord_forces(
                     coords, forces, self.cg_map, mapping, force_stride, batch_size
                 )
+                # update the entries with the sparse version
+                self.cg_map = cg_map
                 self.force_map = force_map
             else:  # all frames were removed by cis-filtering
                 cg_coords = None
@@ -431,12 +432,12 @@ class SampleCollection:
             if not hasattr(self, "cg_map"):
                 warnings.warn("No cg coordinate map found. Skipping save.")
             else:
-                np.save(f"{mol_save_templ}cg_coord_map.npy", self.cg_map)
+                np.save(f"{mol_save_templ}cg_coord_map.npy", self.cg_map.toarray())
 
             if not hasattr(self, "force_map"):
                 warnings.warn("No cg force map found. Skipping save.")
             else:
-                np.save(f"{mol_save_templ}cg_force_map.npy", self.force_map)
+                np.save(f"{mol_save_templ}cg_force_map.npy", self.force_map.toarray())
 
     def load_cg_force_map(self, save_dir: str) -> np.ndarray:
         """

--- a/input_generator/utils.py
+++ b/input_generator/utils.py
@@ -17,16 +17,18 @@ from aggforce import (
 
 from .prior_gen import PriorBuilder
 
-def cg_matmul(timeseries_arr: np.ndarray, map_arr: Union[np.ndarray,sparray]) -> np.ndarray:
+def cg_matmul(map_arr: Union[np.ndarray,sparray],timeseries_arr: np.ndarray) -> np.ndarray:
     r"""Function to perform array multiplication for both numpy and scipy sparse arrays
     
     Parameters
     ----------
 
+    map_arr : Union[np.ndarray,sparray]
+        array of shape (n_beads,n_atoms) representing a linear CG mapping
+
     timeseries_arr : np.ndarray
         array of shape (n_frames,n_atoms,3) holding coordinate or force information 
-    map_arr:
-        array of shape (n_beads,n_atoms) representing a linear CG mapping
+    
 
 
     Returns
@@ -39,10 +41,11 @@ def cg_matmul(timeseries_arr: np.ndarray, map_arr: Union[np.ndarray,sparray]) ->
     assert len(map_arr.shape) == 2, "Map doesn't have shape (n_beads,n_atoms)"
     assert map_arr.shape[1] == timeseries_arr.shape[1], "`n_atoms` doesn't concide in the map and "
     if issubclass(type(map_arr),sparray):
-        # case when we are using sparse arrays for multiplication
+        # scipy sparse arrays dont support the same broadcasting than numpy
+        # we need to explicitly slice every frame and then stack them all
         return np.stack([map_arr @ timeseries_arr[i,:,:]  for i in range(timeseries_arr.shape[0])])
     elif isinstance(map_arr,np.ndarray):
-        # case when we are using sparse arrays for multiplication
+        # when using numpy non-sparse arrays, broadcasting over the frame dimension is supported
         return map_arr @ timeseries_arr
     else:
         raise ValueError(f"Map of type {type(map_arr)} is not supported")
@@ -178,7 +181,7 @@ def batch_matmul(map_matrix, X, batch_size):
         # Perform matrix multiplication:
         # map_matrix (CG, FG) multiplied by each X_batch (FG, 3) gives (GC, 3) for each sample.
         # The broadcasting ensures the result is (batch, CG, 3)
-        result_batch = cg_matmul(X_batch,map_matrix)
+        result_batch = cg_matmul(map_matrix,X_batch)
         results.append(result_batch)
     # Concatenate all chunks along the first axis (M dimension)
     return np.concatenate(results, axis=0)
@@ -309,8 +312,8 @@ def slice_coord_forces(
         cg_coords = batch_matmul(config_map_matrix, coords, batch_size=batch_size)
         cg_forces = batch_matmul(force_map_matrix, forces, batch_size=batch_size)
     else:
-        cg_coords = cg_matmul(coords,config_map_matrix)
-        cg_forces = cg_matmul(forces,force_map_matrix)
+        cg_coords = cg_matmul(config_map_matrix,coords)
+        cg_forces = cg_matmul(force_map_matrix,forces)
 
     return cg_coords, cg_forces, config_map_matrix, force_map_matrix
 

--- a/input_generator/utils.py
+++ b/input_generator/utils.py
@@ -312,7 +312,7 @@ def slice_coord_forces(
         cg_coords = cg_matmul(coords,config_map_matrix)
         cg_forces = cg_matmul(forces,force_map_matrix)
 
-    return cg_coords, cg_forces, force_map_matrix
+    return cg_coords, cg_forces, config_map_matrix, force_map_matrix
 
 
 def filter_cis_frames(

--- a/scripts/gen_input_data.py
+++ b/scripts/gen_input_data.py
@@ -104,7 +104,7 @@ def process_raw_dataset(
         )
 
         if samples.n_batches > 1 and samples.batch > 1:
-            # this ensures that we are using the same force map accross batches
+            # this ensures that we are using the same force map across batches
             mapping = samples.load_cg_force_map(save_dir)
         else:
             mapping = cg_mapping_strategy
@@ -123,6 +123,8 @@ def process_raw_dataset(
         # the sample object will retain the output so it makes sense to delete them
         del samples.cg_coords
         del samples.cg_forces
+        del samples.cg_map
+        del samples.force_map
 
 
 def build_neighborlists(


### PR DESCRIPTION
Currently, we use numpy arrays to represent the CG mapping. Given that the CG slice mappings are sparse by nature, it makes more sense to use a [scipy sparse array](https://docs.scipy.org/doc/scipy/reference/sparse.html) to represent the mappings. 

Using the sparse array also brings a significant performance improvement for the coordinate and force slicing, specially for large systems. 