### PR TITLE
bugfix packaging with several batches when keep_batches is True

### DIFF
--- a/input_generator/raw_dataset.py
+++ b/input_generator/raw_dataset.py
@@ -317,7 +317,7 @@ class SampleCollection:
             Striding to use for force projection results
         batch_size:
             Batching the coords and forces projection to CG
-        atoms_batch_size:  
+        atoms_batch_size:
             Batch size for processing atoms when inferring constrained atoms
 
         Returns
@@ -344,7 +344,13 @@ class SampleCollection:
                         break
 
                 cg_coords, cg_forces, cg_map, force_map = slice_coord_forces(
-                    coords, forces, self.cg_map, mapping, force_stride, batch_size, atoms_batch_size
+                    coords,
+                    forces,
+                    self.cg_map,
+                    mapping,
+                    force_stride,
+                    batch_size,
+                    atoms_batch_size,
                 )
                 # update the entries with the sparse version
                 self.cg_map = cg_map
@@ -610,7 +616,11 @@ class SampleCollection:
             return True
 
     def has_delta_forces_output(
-        self, training_data_dir: str, force_tag: str = "", mol_num_batches: int = 1, keep_batches: bool = False,
+        self,
+        training_data_dir: str,
+        force_tag: str = "",
+        mol_num_batches: int = 1,
+        keep_batches: bool = False,
     ) -> bool:
         """
         Returns True if cg data exists for this SampleCollection

--- a/input_generator/raw_dataset.py
+++ b/input_generator/raw_dataset.py
@@ -610,7 +610,7 @@ class SampleCollection:
             return True
 
     def has_delta_forces_output(
-        self, training_data_dir: str, force_tag: str = "", mol_num_batches: int = 1
+        self, training_data_dir: str, force_tag: str = "", mol_num_batches: int = 1, keep_batches: bool = False,
     ) -> bool:
         """
         Returns True if cg data exists for this SampleCollection
@@ -632,14 +632,16 @@ class SampleCollection:
         False otherwise
         """
         if mol_num_batches == 1:
-            pos_names_lists = [[self.tag, self.name]]
-        elif mol_num_batches > 1:
+            pos_names_lists = [[self.tag, self.mol_name]]
+        elif mol_num_batches > 1 and not keep_batches:
             pos_names_lists = [
-                [self.tag, self.name, f"batch_{b}"] for b in range(mol_num_batches)
+                [self.tag, self.mol_name, f"batch_{b}"] for b in range(mol_num_batches)
             ]
+        elif mol_num_batches > 1 and keep_batches:
+            pos_names_lists = [[self.tag, self.name]]
         else:
             raise ValueError(
-                f"`n_mol_batch` should be a positive integer, not {mol_num_batches}"
+                f"`mol_num_batches` should be a positive integer, not {mol_num_batches}"
             )
         for bat_list in pos_names_lists:
             save_templ = os.path.join(

--- a/scripts/package_training_data.py
+++ b/scripts/package_training_data.py
@@ -101,6 +101,7 @@ def package_training_data(
                     training_data_dir=training_data_dir,
                     force_tag=force_tag,
                     mol_num_batches=mol_num_batches,
+                    keep_batches=keep_batches
                 ):
                     continue
                 else:

--- a/scripts/package_training_data.py
+++ b/scripts/package_training_data.py
@@ -101,7 +101,7 @@ def package_training_data(
                     training_data_dir=training_data_dir,
                     force_tag=force_tag,
                     mol_num_batches=mol_num_batches,
-                    keep_batches=keep_batches
+                    keep_batches=keep_batches,
                 ):
                     continue
                 else:


### PR DESCRIPTION
There is a bug in the main branch that was introduced in the refactoring when `has_delta_forces_output` was added to the packaging script.

There was a confusion on whether to use `self.name` instead of `self.mol_name` (in case of `mol_num_batches > 1` `self.name` contains `${protein_name}_batch_i` and `self.mol_name` only contains `${protein_name}`). Since in the case  `mol_num_batches > 1` the suffix `batch_i` was artificially added to to `self.name` the code was looking for `${protein_name}_batch_i_batch_i_`. 

The function is now slightly modified to take into account the different possibilities:

- in case `mol_num_batches == 1` : `self.mol_name` is used, for consistency, in this case `self.name == self.mol_name` anyway so there was no bug but the code makes more sense with `self.mol_name` 
- in case `mol_num_batches > 1 and not keep_batches`: the output from all batches needs to be checked since the whole CG output will be loaded (not just one batch), in this case artificially add the batch suffix to `self.mol_name`.
- in case `mol_num_batches > 1 and keep_batches`: only the presence of the current batch needs to be checked, so we use `self.name` to check, that contains `${protein_name}_batch_i`