### PR TITLE
Bugfix/package batched data

### DIFF
--- a/src/mlcg_tk/input_generator/raw_dataset.py
+++ b/src/mlcg_tk/input_generator/raw_dataset.py
@@ -656,7 +656,11 @@ class SampleCollection:
             return True
 
     def has_delta_forces_output(
-        self, training_data_dir: str, force_tag: str = "", mol_num_batches: int = 1, keep_batches: bool = False
+        self,
+        training_data_dir: str,
+        force_tag: str = "",
+        mol_num_batches: int = 1,
+        keep_batches: bool = False,
     ) -> bool:
         """
         Returns True if cg data exists for this SampleCollection
@@ -687,9 +691,15 @@ class SampleCollection:
         #     raise ValueError(
         #         f"`mol_num_batches` should be a positive integer, not {mol_num_batches}"
         #     )
-        pos_names_lists = [[self.tag, self.name]] # Check only the presence of that specific batch or molecule
-        if mol_num_batches > 1 and not keep_batches: # Then, check for the presence of all the batches
-            pos_names_lists = [[self.tag, f"{self.mol_name}_batch_{i}"] for i in range(mol_num_batches)]
+        pos_names_lists = [
+            [self.tag, self.name]
+        ]  # Check only the presence of that specific batch or molecule
+        if (
+            mol_num_batches > 1 and not keep_batches
+        ):  # Then, check for the presence of all the batches
+            pos_names_lists = [
+                [self.tag, f"{self.mol_name}_batch_{i}"] for i in range(mol_num_batches)
+            ]
         for bat_list in pos_names_lists:
             save_templ = os.path.join(
                 training_data_dir,
@@ -792,12 +802,12 @@ class SampleCollection:
         return batch_list
 
     def load_training_inputs(
-        self, 
-        training_data_dir: str, 
-        force_tag: str = "", 
+        self,
+        training_data_dir: str,
+        force_tag: str = "",
         mol_num_batches: int = 1,
         keep_batches: bool = False,
-        stride: int = 1
+        stride: int = 1,
     ) -> Tuple:
         """
         Loads all cg data produced by `save_cg_output` and `get_prior_nls`
@@ -827,12 +837,15 @@ class SampleCollection:
             for b in range(mol_num_batches):
                 save_templ = os.path.join(
                     training_data_dir,
-                    get_output_tag([self.tag, self.mol_name, f"batch_{b}"], placement="before"),
+                    get_output_tag(
+                        [self.tag, self.mol_name, f"batch_{b}"], placement="before"
+                    ),
                 )
                 save_templ_forces = os.path.join(
                     training_data_dir,
                     get_output_tag(
-                        [self.tag, self.mol_name, f"batch_{b}", force_tag], placement="before"
+                        [self.tag, self.mol_name, f"batch_{b}", force_tag],
+                        placement="before",
                     ),
                 )
 

--- a/src/mlcg_tk/input_generator/raw_dataset.py
+++ b/src/mlcg_tk/input_generator/raw_dataset.py
@@ -656,7 +656,7 @@ class SampleCollection:
             return True
 
     def has_delta_forces_output(
-        self, training_data_dir: str, force_tag: str = "", mol_num_batches: int = 1
+        self, training_data_dir: str, force_tag: str = "", mol_num_batches: int = 1, keep_batches: bool = False
     ) -> bool:
         """
         Returns True if cg data exists for this SampleCollection
@@ -677,16 +677,19 @@ class SampleCollection:
         True if cg output for the sample corresponding to prior_tag is present in training_data_dir
         False otherwise
         """
-        if mol_num_batches == 1:
-            pos_names_lists = [[self.tag, self.name]]
-        elif mol_num_batches > 1:
-            pos_names_lists = [
-                [self.tag, self.name, f"batch_{b}"] for b in range(mol_num_batches)
-            ]
-        else:
-            raise ValueError(
-                f"`n_mol_batch` should be a positive integer, not {mol_num_batches}"
-            )
+        # if mol_num_batches == 1:
+        #     pos_names_lists = [[self.tag, self.name]]
+        # elif mol_num_batches > 1:
+        #     pos_names_lists = [
+        #         [self.tag, self.name, f"batch_{b}"] for b in range(mol_num_batches)
+        #     ]
+        # else:
+        #     raise ValueError(
+        #         f"`mol_num_batches` should be a positive integer, not {mol_num_batches}"
+        #     )
+        pos_names_lists = [[self.tag, self.name]] # Check only the presence of that specific batch or molecule
+        if mol_num_batches > 1 and not keep_batches: # Then, check for the presence of all the batches
+            pos_names_lists = [[self.tag, f"{self.mol_name}_batch_{i}"] for i in range(mol_num_batches)]
         for bat_list in pos_names_lists:
             save_templ = os.path.join(
                 training_data_dir,
@@ -789,7 +792,12 @@ class SampleCollection:
         return batch_list
 
     def load_training_inputs(
-        self, training_data_dir: str, force_tag: str = "", stride: int = 1
+        self, 
+        training_data_dir: str, 
+        force_tag: str = "", 
+        mol_num_batches: int = 1,
+        keep_batches: bool = False,
+        stride: int = 1
     ) -> Tuple:
         """
         Loads all cg data produced by `save_cg_output` and `get_prior_nls`
@@ -813,47 +821,35 @@ class SampleCollection:
             training_data_dir, get_output_tag([self.tag, self.name], placement="before")
         )
         cg_embeds = np.load(f"{mol_save_templ}cg_embeds.npy")
-        coord_file_path = f"{save_templ}cg_coords.npy"
-        cg_coords = np.load(coord_file_path)[::stride]
-        save_templ_forces = os.path.join(
-            training_data_dir,
-            get_output_tag([self.tag, self.name, force_tag], placement="before"),
-        )
-        force_file_path = f"{save_templ_forces}delta_forces.npy"
-        cg_forces = np.load(force_file_path)[::stride]
-        return cg_coords, cg_forces, cg_embeds
+        if mol_num_batches > 1 and not keep_batches:
+            cg_coords = []
+            cg_forces = []
+            for b in range(mol_num_batches):
+                save_templ = os.path.join(
+                    training_data_dir,
+                    get_output_tag([self.tag, self.mol_name, f"batch_{b}"], placement="before"),
+                )
+                save_templ_forces = os.path.join(
+                    training_data_dir,
+                    get_output_tag(
+                        [self.tag, self.mol_name, f"batch_{b}", force_tag], placement="before"
+                    ),
+                )
 
-    def load_all_batches_training_inputs(
-        self,
-        training_data_dir: str,
-        force_tag: str = "",
-        mol_num_batches: int = 1,
-        stride: int = 1,
-    ):
-        mol_save_templ = os.path.join(
-            training_data_dir, get_output_tag([self.tag, self.name], placement="before")
-        )
-        cg_embeds = np.load(f"{mol_save_templ}cg_embeds.npy")
-        cg_coords = []
-        cg_forces = []
-        for b in range(mol_num_batches):
-            save_templ = os.path.join(
-                training_data_dir,
-                get_output_tag([self.tag, self.name, f"batch_{b}"], placement="before"),
-            )
+                cg_coords.append(np.load(f"{save_templ}cg_coords.npy"))
+                cg_forces.append(np.load(f"{save_templ_forces}delta_forces.npy"))
+
+            cg_coords = np.concatenate(cg_coords)[::stride]
+            cg_forces = np.concatenate(cg_forces)[::stride]
+        else:
+            coord_file_path = f"{save_templ}cg_coords.npy"
+            cg_coords = np.load(coord_file_path)[::stride]
             save_templ_forces = os.path.join(
                 training_data_dir,
-                get_output_tag(
-                    [self.tag, self.name, f"batch_{b}", force_tag], placement="before"
-                ),
+                get_output_tag([self.tag, self.name, force_tag], placement="before"),
             )
-
-            cg_coords.append(np.load(f"{save_templ}cg_coords.npy"))
-            cg_forces.append(np.load(f"{save_templ_forces}delta_forces.npy"))
-
-        cg_coords = np.concatenate(cg_coords)[::stride]
-        cg_forces = np.concatenate(cg_forces)[::stride]
-
+            force_file_path = f"{save_templ_forces}delta_forces.npy"
+            cg_forces = np.load(force_file_path)[::stride]
         return cg_coords, cg_forces, cg_embeds
 
 

--- a/src/mlcg_tk/input_generator/raw_dataset.py
+++ b/src/mlcg_tk/input_generator/raw_dataset.py
@@ -671,7 +671,7 @@ class SampleCollection:
         ----------
         training_data_dir:
             Location of saved cg data
-        prior_tag:
+        force_tag:
             String identifying the specific combination of prior terms
         mol_num_batches : int
             number of batches in which the molecule is suposed to be saved
@@ -681,16 +681,7 @@ class SampleCollection:
         True if cg output for the sample corresponding to prior_tag is present in training_data_dir
         False otherwise
         """
-        # if mol_num_batches == 1:
-        #     pos_names_lists = [[self.tag, self.name]]
-        # elif mol_num_batches > 1:
-        #     pos_names_lists = [
-        #         [self.tag, self.name, f"batch_{b}"] for b in range(mol_num_batches)
-        #     ]
-        # else:
-        #     raise ValueError(
-        #         f"`mol_num_batches` should be a positive integer, not {mol_num_batches}"
-        #     )
+
         pos_names_lists = [
             [self.tag, self.name]
         ]  # Check only the presence of that specific batch or molecule

--- a/src/mlcg_tk/scripts/package_training_data.py
+++ b/src/mlcg_tk/scripts/package_training_data.py
@@ -103,7 +103,7 @@ def package_training_data(
                 ):
                     continue
                 else:
-                    if mol_num_batches and not keep_batches:
+                    if mol_num_batches > 1 and not keep_batches:
                         non_empty_names.append(samples.mol_name)
                     else:
                         non_empty_names.append(samples.name)

--- a/src/mlcg_tk/scripts/package_training_data.py
+++ b/src/mlcg_tk/scripts/package_training_data.py
@@ -99,32 +99,30 @@ def package_training_data(
                     training_data_dir=training_data_dir,
                     force_tag=force_tag,
                     mol_num_batches=mol_num_batches,
+                    keep_batches=keep_batches,
                 ):
                     continue
                 else:
-                    non_empty_names.append(samples.mol_name)
+                    if mol_num_batches and not keep_batches:
+                        non_empty_names.append(samples.mol_name)
+                    else:
+                        non_empty_names.append(samples.name)
+
+                (
+                    cg_coords,
+                    cg_delta_forces,
+                    cg_embeds,
+                ) = samples.load_training_inputs(
+                    training_data_dir=training_data_dir,
+                    force_tag=force_tag,
+                    mol_num_batches=mol_num_batches,
+                    keep_batches=keep_batches,
+                )
 
                 if mol_num_batches > 1 and not keep_batches:
-                    (
-                        cg_coords,
-                        cg_delta_forces,
-                        cg_embeds,
-                    ) = samples.load_all_batches_training_inputs(
-                        training_data_dir=training_data_dir,
-                        force_tag=force_tag,
-                        mol_num_batches=mol_num_batches,
-                    )
+                    name = f"{samples.tag}{samples.mol_name}"
                 else:
-                    (
-                        cg_coords,
-                        cg_delta_forces,
-                        cg_embeds,
-                    ) = samples.load_training_inputs(
-                        training_data_dir=training_data_dir,
-                        force_tag=force_tag,
-                    )
-
-                name = f"{samples.tag}{samples.name}"
+                    name = f"{samples.tag}{samples.name}"
                 hdf_group = metaset.create_group(name)
 
                 hdf_group.create_dataset("cg_coords", data=cg_coords.astype(np.float32))
@@ -133,25 +131,16 @@ def package_training_data(
                 )
                 hdf_group.attrs["cg_embeds"] = cg_embeds
                 hdf_group.attrs["N_frames"] = cg_coords.shape[0]
+                if mol_num_batches > 1 and not keep_batches:
+                    print("All batches saved in one molecule - exit batch loop")
+                    break
 
     if save_partition:
         # Create partition file
         fnout_part = osp.join(save_dir, f"partition{output_tag}.yaml")
         if single_protein:
-            if keep_batches and mol_num_batches > 1:
-                train_mols = [
-                    f"{dataset_tag}{name}_batch_{b}"
-                    for b in range(mol_num_batches)
-                    for name in non_empty_names
-                ]
-                val_mols = [
-                    f"{dataset_tag}{name}_batch_{b}"
-                    for b in range(mol_num_batches)
-                    for name in non_empty_names
-                ]
-            else:
-                train_mols = [f"{dataset_tag}{name}" for name in non_empty_names]
-                val_mols = [f"{dataset_tag}{name}" for name in non_empty_names]
+            train_mols = [f"{dataset_tag}{name}" for name in non_empty_names]
+            val_mols = [f"{dataset_tag}{name}" for name in non_empty_names]
             if train_size == None:
                 raise ValueError(
                     "For single-protein partitions, a train size has to be specified"


### PR DESCRIPTION
# PR Checklist

- [x] Bug fix
- [x] Black formatting

---

### Describe your changes here:
There is a bug in the main branch that was introduced in the refactoring when has_delta_forces_output was added to the packaging script.

There was a confusion on whether to use self.name instead of self.mol_name (in case of mol_num_batches > 1 self.name contains ${protein_name}_batch_i and self.mol_name only contains ${protein_name}). Since in the case mol_num_batches > 1 the suffix batch_i was artificially added to to self.name the code was looking for ${protein_name}_batch_i_batch_i_.

The function is now slightly modified to take into account the different possibilities:

- in case `mol_num_batches > 1` and `not keep_batches`: the output from all batches needs to be checked since the whole CG output will be loaded (not just one batch), in this case artificially add the batch suffix to `self.mol_name`. Then all batches are checked, loaded and saved into a single molecule.

- in case `mol_num_batches > 1` and `keep_batches`: only the presence of the current batch needs to be checked, so we use `self.name` to check, that contains `${protein_name}_batch_i`

- in case `mol_num_batches == 1 `: `self.name` is used, since in this case `self.name == self.mol_name`, to gather this case with the previous one in the same condition.

The function `load_training_inputs` was also modified to remove the need for a second function `load_all_batches_training_inputs` that was doing the same but for all batches.