### PR TITLE
gen_sim_input.py saves the cg pdb.

### DIFF
--- a/src/mlcg_tk/scripts/gen_sim_input.py
+++ b/src/mlcg_tk/scripts/gen_sim_input.py
@@ -115,6 +115,8 @@ def process_sim_input(
                 cg_mass_list.append(cg_masses)
                 cg_nls_list.append(prior_nls)
 
+        samples.save_cg_output(save_dir, save_coord_force=False, save_cg_maps=False)
+
     data_list = []
     for coords, types, masses, nls in zip(
         cg_coord_list, cg_type_list, cg_mass_list, cg_nls_list


### PR DESCRIPTION
# PR Checklist

- [] Bug fix
- [x] Feature addition/change
- [] Documentation addition/change
- [] Test addition/change
- [] Black formatting

---

Adds saving of CG PDB output in gen_sim_input.py by enabling samples.save_cg_output(save_dir, save_coord_force=False, save_cg_maps=False). This ensures coarse-grained structures are written to disk during input generation for sims for easier use.